### PR TITLE
Attach camera to the player

### DIFF
--- a/libs/client_lib/src/camera.rs
+++ b/libs/client_lib/src/camera.rs
@@ -2,6 +2,8 @@ use crate::{CurrentPlayerNetId, MainCameraEntity};
 use bevy::prelude::*;
 use mr_shared_lib::{player::PlayerUpdates, GameTime, COMPONENT_FRAMEBUFFER_LIMIT};
 
+pub const CAMERA_OFFSET: (f32, f32, f32) = (5.0, 10.0, -14.0);
+
 pub fn camera_follow_player(
     time: Res<GameTime>,
     mut player_updates: ResMut<PlayerUpdates>,
@@ -22,7 +24,11 @@ pub fn camera_follow_player(
                 .get_mut(main_camera_entity.0)
                 .expect("expected a main camera");
 
-            camera_transform.translation = Vec3::new(5.0 + position.x, 10.0, -14.0 + position.y);
+            camera_transform.translation = Vec3::new(
+                CAMERA_OFFSET.0 + position.x,
+                CAMERA_OFFSET.1,
+                CAMERA_OFFSET.2 + position.y,
+            );
         }
     }
 }

--- a/libs/client_lib/src/camera.rs
+++ b/libs/client_lib/src/camera.rs
@@ -1,0 +1,28 @@
+use crate::{CurrentPlayerNetId, MainCameraEntity};
+use bevy::prelude::*;
+use mr_shared_lib::{player::PlayerUpdates, GameTime, COMPONENT_FRAMEBUFFER_LIMIT};
+
+pub fn camera_follow_player(
+    time: Res<GameTime>,
+    mut player_updates: ResMut<PlayerUpdates>,
+    current_player_net_id: Res<CurrentPlayerNetId>,
+    main_camera_entity: Res<MainCameraEntity>,
+    mut cameras: Query<(&mut Transform, &bevy::render::camera::Camera)>,
+) {
+    // Get the player's position and update the camera accordingly.
+    if let Some(player_net_id) = current_player_net_id.0 {
+        let position_updates = player_updates.get_position_mut(
+            player_net_id,
+            time.frame_number,
+            COMPONENT_FRAMEBUFFER_LIMIT,
+        );
+
+        if let Some(position) = position_updates.last().and_then(|v| v.as_ref()) {
+            let (mut camera_transform, _camera) = cameras
+                .get_mut(main_camera_entity.0)
+                .expect("expected a main camera");
+
+            camera_transform.translation = Vec3::new(5.0 + position.x, 10.0, -14.0 + position.y);
+        }
+    }
+}

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -232,9 +232,14 @@ fn basic_scene(mut commands: Commands) {
         ..Default::default()
     });
     // Camera.
+    let camera_translation = Vec3::new(
+        camera::CAMERA_OFFSET.0,
+        camera::CAMERA_OFFSET.1,
+        camera::CAMERA_OFFSET.2,
+    );
     let main_camera_entity = commands
         .spawn_bundle(PerspectiveCameraBundle {
-            transform: Transform::from_translation(Vec3::new(5.0, 10.0, -14.0))
+            transform: Transform::from_translation(camera_translation)
                 .looking_at(Vec3::default(), Vec3::Y),
             ..Default::default()
         })

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -33,6 +33,7 @@ use mr_shared_lib::{
 };
 use std::borrow::Cow;
 
+mod camera;
 mod helpers;
 mod input;
 mod net;
@@ -50,7 +51,8 @@ impl Plugin for MuddleClientPlugin {
             .with_system(maintain_connection.system())
             .with_system(process_network_events.system())
             .with_system(input::track_input_events.system())
-            .with_system(input::cast_mouse_ray.system());
+            .with_system(input::cast_mouse_ray.system())
+            .with_system(camera::camera_follow_player.system());
         let broadcast_updates_stage =
             SystemStage::parallel().with_system(send_network_updates.system());
         let post_tick_stage = SystemStage::single_threaded()


### PR DESCRIPTION
Fixes #20

This PR attaches the camera to the current player. The issue this addresses doesn't specify whether this is always the expected behavior (it just says "a player"), but this should be a workable solution.

- Created a new system `camera_follow_player`
    - Gets the current player's position from `player_updates`
    - Gets the main camera
    - Sets the camera's position to a specific offset from the player
- This also introduces a new constant for the camera's offset, which is now used to initialize the camera as well


This could possibly be optimized to use player updates instead of constantly tracking the player, but that may be unnecessarily complex. The camera's orientation could also be easily updated using this system.