### PR TITLE
Builder mode v1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,7 @@
-# NOTE: For maximum performance, build using a nightly compiler (see ./rust-toolchain in the project root).
+# Add the contents of this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
+
+# NOTE: For maximum performance, build using a nightly compiler
+# If you are using rust stable, remove the "-Zshare-generics=y" below.
 
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
@@ -7,8 +10,13 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y", "-Zrun-dsymutil=no"]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
 rustflags = ["-Zshare-generics=y"]
+
+# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
+# In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+#[profile.dev]
+#debug = 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,6 +3022,7 @@ name = "mr_shared_lib"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_egui",
  "bevy_networking_turbulence",
  "bevy_rapier3d",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,8 +386,7 @@ checksum = "0d5f2f58f0aec3c50a20799792c3705e80dd7df327e79791cacec197e84e5e61"
 [[package]]
 name = "bevy-inspector-egui"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc705295fc79159a6d96888ed20de42ed143da50a31b72b3060b2c5099fb024"
+source = "git+https://github.com/jakobhellermann/bevy-inspector-egui.git#ecc6a9fdf8af9a475335689eabe8d015c336371f"
 dependencies = [
  "bevy",
  "bevy-inspector-egui-derive",
@@ -400,8 +399,7 @@ dependencies = [
 [[package]]
 name = "bevy-inspector-egui-derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10a625d3c87e6662404eb21b5de6356c63a338c933436b177adbacd0edea606"
+source = "git+https://github.com/jakobhellermann/bevy-inspector-egui.git#ecc6a9fdf8af9a475335689eabe8d015c336371f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -555,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_egui"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3de8da8d35ee092c04816725eb9ab9f4dc809f0c1ad2cda4de74042fa8a3454"
+checksum = "deb8eba352b755e7b5b934a7ceade017dde82ecea6585ffd65f6690abbf1ff20"
 dependencies = [
  "bevy",
  "clipboard",
@@ -1651,9 +1649,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "egui"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7d6535c3ecdc8627a72c1c52d052d66cd9f71c238428690cc46bef9d1f2bce"
+checksum = "788148861d80b87d28d64440a3d31cae190e50ccc3ea585597466d38428365d7"
 dependencies = [
  "epaint",
 ]
@@ -1666,9 +1664,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "emath"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ed72c14666517e5c0198490864adea871081abe4f5523af8c3f4f56595142e"
+checksum = "3e73d6c8c70eadb71756fbbc3c303ab25e163b46b656886dd250de5636efea12"
 
 [[package]]
 name = "encoding_rs"
@@ -1704,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a19eff631454edbe5abe4693be00be0c1ea9832d727dc385c16841caa2d0162"
+checksum = "80e2db640801230bdda80629bc3a063927a462f5eaf38a98da676954e78ccb99"
 dependencies = [
  "ahash 0.7.2",
  "atomic_refcell",

--- a/libs/client_lib/Cargo.toml
+++ b/libs/client_lib/Cargo.toml
@@ -13,8 +13,8 @@ use-webrtc = ["bevy_networking_turbulence/use-webrtc"]
 web = ["mr_shared_lib/web", "chrono/wasmbind"]
 
 [dependencies]
-bevy_egui = "0.4.2"
-bevy-inspector-egui = "0.5.1"
+bevy_egui = "0.5.0"
+bevy-inspector-egui = { git = "https://github.com/jakobhellermann/bevy-inspector-egui.git" }
 bevy_networking_turbulence = { version = "0.2.0", default-features = false }
 bevy_rapier3d = { version = "0.10.2", features = ["wasm-bindgen"] }
 chrono = "0.4.19"

--- a/libs/client_lib/src/helpers.rs
+++ b/libs/client_lib/src/helpers.rs
@@ -1,4 +1,4 @@
-use crate::input::MouseRay;
+use crate::{input::MouseRay, CurrentPlayerNetId};
 use bevy::{
     ecs::{
         entity::Entity,
@@ -18,6 +18,22 @@ use bevy_rapier3d::{
         pipeline::QueryPipeline,
     },
 };
+use mr_shared_lib::{messages::PlayerNetId, player::Player};
+use std::collections::HashMap;
+
+#[derive(SystemParam)]
+pub struct PlayerParams<'a> {
+    pub players: Res<'a, HashMap<PlayerNetId, Player>>,
+    pub current_player_net_id: Res<'a, CurrentPlayerNetId>,
+}
+
+impl<'a> PlayerParams<'a> {
+    pub fn current_player(&self) -> Option<&Player> {
+        self.current_player_net_id
+            .0
+            .and_then(|net_id| self.players.get(&net_id))
+    }
+}
 
 #[derive(SystemParam)]
 pub struct MouseEntityPicker<'a> {

--- a/libs/client_lib/src/input.rs
+++ b/libs/client_lib/src/input.rs
@@ -196,7 +196,11 @@ pub fn cast_mouse_ray(
 
     mouse_world_position.0 = {
         let ray_direction = Vec3::new(mouse_ray.0.dir.x, mouse_ray.0.dir.y, mouse_ray.0.dir.z);
-        let ray_origin = Vec3::new(mouse_ray.0.origin.x, mouse_ray.0.origin.y, mouse_ray.0.origin.z);
+        let ray_origin = Vec3::new(
+            mouse_ray.0.origin.x,
+            mouse_ray.0.origin.y,
+            mouse_ray.0.origin.z,
+        );
         let plane_normal = Vec3::Z;
         let denom = plane_normal.dot(ray_direction);
         if denom.abs() > f32::EPSILON {

--- a/libs/client_lib/src/input.rs
+++ b/libs/client_lib/src/input.rs
@@ -47,7 +47,7 @@ pub struct InputEvents<'a> {
 
 /// Represents a cursor position in window coordinates (the ones that are coming from Window events).
 #[derive(Default)]
-pub struct MousePosition(pub Vec2);
+pub struct MouseScreenPosition(pub Vec2);
 
 /// MouseRay intersection with the (center=[0.0, 0.0, 0.0], normal=[0.0, 0.0, 1.0]) plane.
 #[derive(Default)]
@@ -89,7 +89,7 @@ pub fn track_input_events(
     mut ui_params: UiParams,
     mut world_inspector_params: ResMut<WorldInspectorParams>,
     mut player_updates_params: PlayerUpdatesParams,
-    mut mouse_position: ResMut<MousePosition>,
+    mut mouse_position: ResMut<MouseScreenPosition>,
     keyboard_input: Res<Input<KeyCode>>,
 ) {
     if ui_params.egui_context.ctx().wants_keyboard_input() {
@@ -173,7 +173,7 @@ pub fn track_input_events(
 
 pub fn cast_mouse_ray(
     windows: Res<Windows>,
-    mouse_position: Res<MousePosition>,
+    mouse_position: Res<MouseScreenPosition>,
     main_camera_entity: Res<MainCameraEntity>,
     cameras: Query<(
         &GlobalTransform,

--- a/libs/client_lib/src/input.rs
+++ b/libs/client_lib/src/input.rs
@@ -9,6 +9,7 @@ use bevy::{
     prelude::*,
     render::camera::CameraProjection,
 };
+use bevy_egui::EguiContext;
 use bevy_inspector_egui::WorldInspectorParams;
 use bevy_rapier3d::{na, rapier::geometry::Ray};
 use chrono::{DateTime, Utc};
@@ -71,18 +72,28 @@ pub struct PlayerUpdatesParams<'a> {
     player_requests: ResMut<'a, PlayerRequestsQueue>,
 }
 
+#[derive(SystemParam)]
+pub struct UiParams<'a> {
+    egui_context: Res<'a, EguiContext>,
+    debug_ui_state: ResMut<'a, DebugUiState>,
+}
+
 pub fn track_input_events(
     mut input_events: InputEvents,
     time: Res<GameTime>,
-    mut debug_ui_state: ResMut<DebugUiState>,
+    mut ui_params: UiParams,
     mut world_inspector_params: ResMut<WorldInspectorParams>,
     mut player_updates_params: PlayerUpdatesParams,
     mut mouse_position: ResMut<MousePosition>,
     keyboard_input: Res<Input<KeyCode>>,
 ) {
+    if ui_params.egui_context.ctx().wants_keyboard_input() {
+        return;
+    }
+
     process_hotkeys(
         &keyboard_input,
-        &mut debug_ui_state,
+        &mut ui_params.debug_ui_state,
         &mut world_inspector_params,
         &mut player_updates_params,
     );

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -4,6 +4,7 @@ use crate::{
     input::{LevelObjectRequestsQueue, MouseRay, PlayerRequestsQueue},
     net::{maintain_connection, process_network_events, send_network_updates, send_requests},
     ui::debug_ui::update_debug_ui_state,
+    visuals::control_builder_visibility,
 };
 use bevy::{
     app::{AppBuilder, Plugin},
@@ -30,6 +31,7 @@ use bevy_inspector_egui::{WorldInspectorParams, WorldInspectorPlugin};
 use chrono::{DateTime, Utc};
 use mr_shared_lib::{
     framebuffer::FrameNumber,
+    game::client_factories::VisibilitySettings,
     messages::{EntityNetId, PlayerNetId},
     net::{ConnectionState, ConnectionStatus, MessageId},
     GameState, GameTime, MuddleSharedPlugin, SimulationTime, COMPONENT_FRAMEBUFFER_LIMIT,
@@ -43,6 +45,7 @@ mod helpers;
 mod input;
 mod net;
 mod ui;
+mod visuals;
 
 const TICKING_SPEED_FACTOR: u16 = 10;
 
@@ -71,6 +74,7 @@ impl Plugin for MuddleClientPlugin {
             .with_system(send_network_updates.system())
             .with_system(send_requests.system());
         let post_tick_stage = SystemStage::parallel()
+            .with_system(control_builder_visibility.system())
             .with_system(reattach_camera.system().label("reattach_camera"))
             .with_system(move_free_camera_pivot.system().after("reattach_camera"))
             .with_system(pause_simulation.system().label("pause_simulation"))
@@ -125,6 +129,7 @@ impl Plugin for MuddleClientPlugin {
         world.get_resource_or_insert_with(LevelObjectRequestsQueue::default);
         world.get_resource_or_insert_with(LevelObjectCorrelations::default);
         world.get_resource_or_insert_with(MouseRay::default);
+        world.get_resource_or_insert_with(VisibilitySettings::default);
     }
 }
 

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -91,7 +91,7 @@ impl Plugin for MuddleClientPlugin {
             .add_plugin(EguiPlugin)
             .add_plugin(WorldInspectorPlugin::new())
             .init_resource::<WindowInnerSize>()
-            .init_resource::<input::MousePosition>()
+            .init_resource::<input::MouseScreenPosition>()
             // Startup systems.
             .add_startup_system(init_state.system())
             .add_startup_system(basic_scene.system())

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -387,7 +387,7 @@ fn control_ticking_speed(
         };
     }
 
-    if prev_tick_rate.rate != params.tick_rate.rate || *prev_generation != params.time.generation {
+    if prev_tick_rate.rate != params.tick_rate.rate || *prev_generation != params.time.session {
         *frames_ticked = 0;
     }
 
@@ -415,7 +415,7 @@ fn control_ticking_speed(
 
     *frames_ticked += 1;
     prev_tick_rate.rate = params.tick_rate.rate;
-    *prev_generation = params.time.generation;
+    *prev_generation = params.time.session;
 }
 
 fn faster_tick_rate() -> u16 {

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -38,6 +38,8 @@ use mr_shared_lib::{
     SIMULATIONS_PER_SECOND,
 };
 use std::borrow::Cow;
+use crate::input::MouseWorldPosition;
+use crate::ui::builder_ui::PlacedLevelObject;
 
 mod camera;
 mod components;
@@ -126,9 +128,11 @@ impl Plugin for MuddleClientPlugin {
         world.get_resource_or_insert_with(CurrentPlayerNetId::default);
         world.get_resource_or_insert_with(ConnectionState::default);
         world.get_resource_or_insert_with(PlayerRequestsQueue::default);
+        world.get_resource_or_insert_with(PlacedLevelObject::default);
         world.get_resource_or_insert_with(LevelObjectRequestsQueue::default);
         world.get_resource_or_insert_with(LevelObjectCorrelations::default);
         world.get_resource_or_insert_with(MouseRay::default);
+        world.get_resource_or_insert_with(MouseWorldPosition::default);
         world.get_resource_or_insert_with(VisibilitySettings::default);
     }
 }

--- a/libs/client_lib/src/lib.rs
+++ b/libs/client_lib/src/lib.rs
@@ -1,9 +1,9 @@
 use crate::{
     camera::{move_free_camera_pivot, reattach_camera},
     components::{CameraPivotDirection, CameraPivotTag},
-    input::{LevelObjectRequestsQueue, MouseRay, PlayerRequestsQueue},
+    input::{LevelObjectRequestsQueue, MouseRay, MouseWorldPosition, PlayerRequestsQueue},
     net::{maintain_connection, process_network_events, send_network_updates, send_requests},
-    ui::debug_ui::update_debug_ui_state,
+    ui::{builder_ui::EditedLevelObject, debug_ui::update_debug_ui_state},
     visuals::control_builder_visibility,
 };
 use bevy::{
@@ -38,8 +38,6 @@ use mr_shared_lib::{
     SIMULATIONS_PER_SECOND,
 };
 use std::borrow::Cow;
-use crate::input::MouseWorldPosition;
-use crate::ui::builder_ui::PlacedLevelObject;
 
 mod camera;
 mod components;
@@ -111,7 +109,8 @@ impl Plugin for MuddleClientPlugin {
             .add_system(ui::overlay_ui::connection_status_overlay.system())
             .add_system(ui::debug_ui::inspect_object.system())
             .add_system(ui::help_ui::help_ui.system())
-            .add_system(ui::builder_ui::builder_ui.system());
+            // Not only Egui for builder mode.
+            .add_system_set(ui::builder_ui::builder_system_set());
 
         let world = builder.world_mut();
         world
@@ -128,7 +127,7 @@ impl Plugin for MuddleClientPlugin {
         world.get_resource_or_insert_with(CurrentPlayerNetId::default);
         world.get_resource_or_insert_with(ConnectionState::default);
         world.get_resource_or_insert_with(PlayerRequestsQueue::default);
-        world.get_resource_or_insert_with(PlacedLevelObject::default);
+        world.get_resource_or_insert_with(EditedLevelObject::default);
         world.get_resource_or_insert_with(LevelObjectRequestsQueue::default);
         world.get_resource_or_insert_with(LevelObjectCorrelations::default);
         world.get_resource_or_insert_with(MouseRay::default);

--- a/libs/client_lib/src/net.rs
+++ b/libs/client_lib/src/net.rs
@@ -842,10 +842,15 @@ fn process_start_game_message(
             (SIMULATIONS_PER_SECOND as f32 * connection_state.rtt_millis() / 1000.0 / 2.0) as u16,
         );
         update_params.target_frames_ahead.frames_count = rtt_frames;
-        update_params.simulation_time.generation = start_game.generation;
+        update_params.simulation_time.server_generation = start_game.generation;
+        update_params.simulation_time.player_generation = start_game.generation;
         update_params.simulation_time.server_frame = start_game.game_state.frame_number;
-        update_params.simulation_time.player_frame =
-            start_game.game_state.frame_number + rtt_frames;
+        let (player_frame, overflown) = start_game.game_state.frame_number.add(rtt_frames);
+        update_params.simulation_time.player_frame = player_frame;
+        if overflown {
+            update_params.simulation_time.player_generation += 1;
+        }
+
         update_params.game_time.frame_number = update_params.simulation_time.player_frame;
 
         update_params.estimated_server_time.frame_number =

--- a/libs/client_lib/src/net.rs
+++ b/libs/client_lib/src/net.rs
@@ -649,6 +649,7 @@ fn process_delta_update_message(
     players: &mut HashMap<PlayerNetId, Player>,
     update_params: &mut UpdateParams,
 ) {
+    log::trace!("Processing DeltaUpdate message: {:?}", delta_update);
     let mut rewind_to_simulation_frame = delta_update.frame_number;
 
     // Calculating how many frames ahead of the server we want to be (implies resizing input buffer for the server).

--- a/libs/client_lib/src/net.rs
+++ b/libs/client_lib/src/net.rs
@@ -834,7 +834,7 @@ fn process_start_game_message(
             start_game.net_id,
             Player::new_with_nickname(PlayerRole::Runner, start_game.nickname),
         );
-        update_params.game_time.generation += 1;
+        update_params.game_time.session += 1;
         let rtt_frames = FrameNumber::new(
             (SIMULATIONS_PER_SECOND as f32 * connection_state.rtt_millis() / 1000.0) as u16,
         );
@@ -842,6 +842,7 @@ fn process_start_game_message(
             (SIMULATIONS_PER_SECOND as f32 * connection_state.rtt_millis() / 1000.0 / 2.0) as u16,
         );
         update_params.target_frames_ahead.frames_count = rtt_frames;
+        update_params.simulation_time.generation = start_game.generation;
         update_params.simulation_time.server_frame = start_game.game_state.frame_number;
         update_params.simulation_time.player_frame =
             start_game.game_state.frame_number + rtt_frames;

--- a/libs/client_lib/src/net.rs
+++ b/libs/client_lib/src/net.rs
@@ -720,6 +720,12 @@ fn process_delta_update_message(
         .collect();
 
     for player_net_id in players_to_remove {
+        log::debug!(
+            "Player ({}) is not mentioned in the delta update (update frame: {}, current frame: {})",
+            player_net_id.0,
+            delta_update.frame_number,
+            update_params.game_time.frame_number
+        );
         update_params.despawn_player_commands.push(DespawnPlayer {
             net_id: player_net_id,
             frame_number: delta_update.frame_number,

--- a/libs/client_lib/src/ui/builder_ui.rs
+++ b/libs/client_lib/src/ui/builder_ui.rs
@@ -242,6 +242,32 @@ pub fn builder_ui(
                         ui.label("Route type");
                         route_type(ui, &mut dirty_level_object);
                         ui.end_row();
+
+                        if let Some(route) = &mut dirty_level_object.route {
+                            ui.label("Period (frames)");
+                            ui.add(
+                                egui::widgets::DragValue::new(&mut route.period)
+                                    .speed(0.1)
+                                    .clamp_range(
+                                        SIMULATIONS_PER_SECOND..=SIMULATIONS_PER_SECOND * 60,
+                                    ),
+                            );
+                            ui.end_row();
+
+                            ui.label("Period (second)");
+                            ui.label(format!(
+                                "{:.2}",
+                                route.period.value() as f32 / SIMULATIONS_PER_SECOND as f32
+                            ));
+                            ui.end_row();
+
+                            ui.label("Start offset (frames)");
+                            ui.add(
+                                egui::widgets::DragValue::new(&mut route.start_frame_offset)
+                                    .speed(0.1)
+                                    .clamp_range(FrameNumber::new(0)..=route.period),
+                            );
+                        }
                     }
                 });
 

--- a/libs/client_lib/src/ui/builder_ui.rs
+++ b/libs/client_lib/src/ui/builder_ui.rs
@@ -16,7 +16,7 @@ use bevy_egui::{egui, egui::Ui, EguiContext};
 use mr_shared_lib::{
     framebuffer::FrameNumber,
     game::{
-        components::{LevelObjectLabel, Spawned},
+        components::{LevelObjectLabel, LevelObjectStaticGhost, Spawned},
         level::{LevelObject, LevelObjectDesc, LevelState, ObjectRoute, ObjectRouteDesc},
         level_objects::{CubeDesc, PlaneDesc, RoutePointDesc},
     },
@@ -45,6 +45,7 @@ pub struct LevelObjects<'a> {
     level_state: Res<'a, LevelState>,
     entity_registry: Res<'a, EntityRegistry<EntityNetId>>,
     query: Query<'a, (Entity, &'static LevelObjectLabel, &'static Spawned)>,
+    ghosts_query: Query<'a, &'static LevelObjectStaticGhost>,
 }
 
 #[derive(Default)]
@@ -106,6 +107,15 @@ pub fn builder_ui(
     if let Some((entity, _, picked_level_object)) = mouse_entity_picker
         .take_picked_entity()
         .and_then(|entity| {
+            // Checking whether we've clicked a ghost.
+            if let Ok(LevelObjectStaticGhost(ghost_parent)) = level_objects.ghosts_query.get(entity)
+            {
+                return Some((
+                    *ghost_parent,
+                    level_objects.entity_registry.get_id(*ghost_parent).unwrap(),
+                ));
+            }
+            // Checking normal objects.
             level_objects
                 .entity_registry
                 .get_id(entity)

--- a/libs/client_lib/src/ui/builder_ui.rs
+++ b/libs/client_lib/src/ui/builder_ui.rs
@@ -1,28 +1,34 @@
 use crate::{
-    helpers::MouseEntityPicker, input::LevelObjectRequestsQueue, CurrentPlayerNetId,
+    helpers::{MouseEntityPicker, PlayerParams},
+    input::LevelObjectRequestsQueue,
+    ui::widgets::sortable::{sortable_list, ListItem},
     LevelObjectCorrelations,
 };
 use bevy::{
     ecs::{
         entity::Entity,
-        system::{Local, Res, ResMut, SystemParam},
+        system::{Local, Query, Res, ResMut, SystemParam},
     },
     log,
     math::Vec2,
 };
 use bevy_egui::{egui, EguiContext};
 use mr_shared_lib::{
+    framebuffer::FrameNumber,
     game::{
-        level::{LevelObject, LevelObjectDesc, LevelState},
+        components::LevelObjectLabel,
+        level::{LevelObject, LevelObjectDesc, LevelState, ObjectRoute, ObjectRouteDesc},
         level_objects::{CubeDesc, PivotPointDesc, PlaneDesc},
     },
-    messages::{EntityNetId, PlayerNetId, SpawnLevelObjectRequest, SpawnLevelObjectRequestBody},
+    messages::{EntityNetId, SpawnLevelObjectRequest, SpawnLevelObjectRequestBody},
     net::MessageId,
-    player::{Player, PlayerRole},
+    player::PlayerRole,
     registry::EntityRegistry,
+    SIMULATIONS_PER_SECOND,
 };
 use std::collections::HashMap;
 
+#[derive(Clone)]
 pub struct PickedLevelObject {
     entity: Entity,
     level_object: LevelObject,
@@ -35,27 +41,30 @@ pub struct LevelObjects<'a> {
     picked_level_object: Local<'a, Option<PickedLevelObject>>,
     level_state: Res<'a, LevelState>,
     entity_registry: Res<'a, EntityRegistry<EntityNetId>>,
+    query: Query<'a, (Entity, &'static LevelObjectLabel)>,
+}
+
+#[derive(Default)]
+pub struct BuilderUiState {
+    filter: String,
 }
 
 pub fn builder_ui(
     egui_context: ResMut<EguiContext>,
+    mut builder_ui_state: Local<BuilderUiState>,
     mut mouse_entity_picker: MouseEntityPicker,
-    current_player_net_id: Res<CurrentPlayerNetId>,
-    players: Res<HashMap<PlayerNetId, Player>>,
+    player_params: PlayerParams,
     mut level_object_correlations: ResMut<LevelObjectCorrelations>,
     mut level_object_requests: ResMut<LevelObjectRequestsQueue>,
     mut level_objects: LevelObjects,
 ) {
-    let current_player_id = match current_player_net_id.0 {
-        Some(current_player_id) => current_player_id,
+    let player = match player_params.current_player() {
+        Some(player) => player,
         None => {
             *level_objects.picked_level_object = None;
             return;
         }
     };
-    let player = players
-        .get(&current_player_id)
-        .expect("Expected a current player to exist");
     if !matches!(player.role, PlayerRole::Builder) {
         *level_objects.picked_level_object = None;
         return;
@@ -141,9 +150,58 @@ pub fn builder_ui(
         if let Some(PickedLevelObject {
             entity: _,
             level_object,
-            dirty_level_object,
-        }) = &mut *level_objects.picked_level_object
+            mut dirty_level_object,
+        }) = level_objects.picked_level_object.clone()
         {
+            ui.label("Create new object:");
+            ui.horizontal_wrapped(|ui| {
+                if ui.button("Plane").clicked() {
+                    let correlation_id = level_object_correlations.next_correlation_id();
+                    *level_objects.pending_correlation = Some(correlation_id);
+                    level_object_requests
+                        .spawn_requests
+                        .push(SpawnLevelObjectRequest {
+                            correlation_id,
+                            body: SpawnLevelObjectRequestBody::New(LevelObjectDesc::Plane(
+                                PlaneDesc {
+                                    position: Vec2::new(0.0, 0.0),
+                                    size: 50.0,
+                                },
+                            )),
+                        });
+                }
+                if ui.button("Cube").clicked() {
+                    let correlation_id = level_object_correlations.next_correlation_id();
+                    *level_objects.pending_correlation = Some(correlation_id);
+                    level_object_requests
+                        .spawn_requests
+                        .push(SpawnLevelObjectRequest {
+                            correlation_id,
+                            body: SpawnLevelObjectRequestBody::New(LevelObjectDesc::Cube(
+                                CubeDesc {
+                                    position: Vec2::new(5.0, 5.0),
+                                    size: 0.4,
+                                },
+                            )),
+                        });
+                }
+                if ui.button("Pivot Point").clicked() {
+                    let correlation_id = level_object_correlations.next_correlation_id();
+                    *level_objects.pending_correlation = Some(correlation_id);
+                    level_object_requests
+                        .spawn_requests
+                        .push(SpawnLevelObjectRequest {
+                            correlation_id,
+                            body: SpawnLevelObjectRequestBody::New(LevelObjectDesc::PivotPoint(
+                                PivotPointDesc {
+                                    position: Vec2::new(-5.0, 5.0),
+                                },
+                            )),
+                        });
+                }
+            });
+            ui.separator();
+
             egui::Grid::new("editing_picked_level_object")
                 .striped(true)
                 .show(ui, |ui| {
@@ -179,7 +237,22 @@ pub fn builder_ui(
                         }
                     });
                     ui.end_row();
+
+                    if dirty_level_object.desc.position().is_some() {
+                        ui.label("Route type");
+                        route_type(ui, &mut dirty_level_object);
+                        ui.end_row();
+                    }
                 });
+
+            if dirty_level_object.desc.position().is_some() {
+                route_settings(
+                    ui,
+                    &mut builder_ui_state,
+                    &mut level_objects,
+                    &mut dirty_level_object,
+                );
+            }
 
             if level_object != dirty_level_object {
                 assert_eq!(level_object.net_id, dirty_level_object.net_id);
@@ -187,54 +260,252 @@ pub fn builder_ui(
                     net_id: level_object.net_id,
                     label: dirty_level_object.label.clone(),
                     desc: dirty_level_object.desc.clone(),
+                    route: dirty_level_object.route.clone(),
                 });
-                *level_object = dirty_level_object.clone();
-            }
-            ui.separator();
-        }
 
-        ui.label("Create new object:");
-        ui.horizontal_wrapped(|ui| {
-            if ui.button("Plane").clicked() {
-                let correlation_id = level_object_correlations.next_correlation_id();
-                *level_objects.pending_correlation = Some(correlation_id);
-                level_object_requests
-                    .spawn_requests
-                    .push(SpawnLevelObjectRequest {
-                        correlation_id,
-                        body: SpawnLevelObjectRequestBody::New(LevelObjectDesc::Plane(PlaneDesc {
-                            position: Vec2::new(0.0, 0.0),
-                            size: 50.0,
-                        })),
-                    });
+                let picked_level_object = level_objects.picked_level_object.as_mut().unwrap();
+                picked_level_object.level_object = dirty_level_object.clone();
+                picked_level_object.dirty_level_object = dirty_level_object;
             }
-            if ui.button("Cube").clicked() {
-                let correlation_id = level_object_correlations.next_correlation_id();
-                *level_objects.pending_correlation = Some(correlation_id);
-                level_object_requests
-                    .spawn_requests
-                    .push(SpawnLevelObjectRequest {
-                        correlation_id,
-                        body: SpawnLevelObjectRequestBody::New(LevelObjectDesc::Cube(CubeDesc {
-                            position: Vec2::new(5.0, 5.0),
-                            size: 0.4,
-                        })),
-                    });
+        }
+    });
+}
+
+fn route_settings(
+    ui: &mut egui::Ui,
+    builder_ui_state: &mut BuilderUiState,
+    level_objects: &mut LevelObjects,
+    dirty_level_object: &mut LevelObject,
+) {
+    let net_id = dirty_level_object.net_id;
+    let label = dirty_level_object.label.clone();
+    let dirty_level_object_route = match &mut dirty_level_object.route {
+        Some(route) => route,
+        None => return,
+    };
+
+    let response = egui::CollapsingHeader::new("Route settings").show(ui, |ui| {
+        match &mut dirty_level_object_route.desc {
+            ObjectRouteDesc::Attached(pivot_point) | ObjectRouteDesc::Radial(pivot_point) => {
+                let point_label = pivot_point
+                    .and_then(|point| level_objects.level_state.objects.get(&point))
+                    .map_or("None".to_owned(), |level_object| level_object.label.clone());
+                ui.label(format!("Pivot point: {}", point_label));
             }
-            if ui.button("Pivot Point").clicked() {
-                let correlation_id = level_object_correlations.next_correlation_id();
-                *level_objects.pending_correlation = Some(correlation_id);
-                level_object_requests
-                    .spawn_requests
-                    .push(SpawnLevelObjectRequest {
-                        correlation_id,
-                        body: SpawnLevelObjectRequestBody::New(LevelObjectDesc::PivotPoint(
-                            PivotPointDesc {
-                                position: Vec2::new(-5.0, 5.0),
-                            },
-                        )),
-                    });
+            ObjectRouteDesc::ForwardCycle(pivot_points)
+            | ObjectRouteDesc::ForwardBackwardsCycle(pivot_points) => {
+                let mut list = vec![ListItem {
+                    id: egui::Id::new(net_id),
+                    label: label.clone(),
+                    data: net_id,
+                    sortable: false,
+                }];
+                let mut duplicate_counts = HashMap::new();
+                for point in &*pivot_points {
+                    if let Some(level_object) = level_objects.level_state.objects.get(point) {
+                        let n = duplicate_counts
+                            .entry(*point)
+                            .and_modify(|count| *count += 1)
+                            .or_insert(0);
+                        list.push(ListItem {
+                            id: egui::Id::new(level_object.net_id).with(n),
+                            label: level_object.label.clone(),
+                            data: level_object.net_id,
+                            sortable: true,
+                        });
+                    }
+                }
+
+                let edited = sortable_list(ui, "route settings", &mut list);
+                if edited {
+                    *pivot_points = list
+                        .into_iter()
+                        .skip(1)
+                        .map(|list_item| list_item.data)
+                        .collect();
+                }
+            }
+        }
+    });
+
+    if response.body_returned.is_some() {
+        ui.horizontal(|ui| {
+            ui.label("Filter:");
+            ui.text_edit_singleline(&mut builder_ui_state.filter);
+            if ui.button("❌").clicked() {
+                builder_ui_state.filter = String::new();
             }
         });
-    });
+        egui::ScrollArea::auto_sized().show(ui, |ui| {
+            ui.horizontal_wrapped(|ui| {
+                for (entity, label) in level_objects.query.iter() {
+                    if !label
+                        .0
+                        .to_lowercase()
+                        .contains(&builder_ui_state.filter.to_lowercase())
+                    {
+                        continue;
+                    }
+
+                    if ui.button(&label.0).clicked() {
+                        let selected_entity_net_id = level_objects
+                            .entity_registry
+                            .get_id(entity)
+                            .expect("Expected a registered level object");
+                        match &mut dirty_level_object_route.desc {
+                            ObjectRouteDesc::Attached(pivot_point)
+                            | ObjectRouteDesc::Radial(pivot_point) => {
+                                *pivot_point = Some(selected_entity_net_id);
+                            }
+                            ObjectRouteDesc::ForwardCycle(pivot_points)
+                            | ObjectRouteDesc::ForwardBackwardsCycle(pivot_points) => {
+                                pivot_points.push(selected_entity_net_id);
+                            }
+                        }
+                    }
+                }
+            });
+        });
+    }
+}
+
+fn route_type(ui: &mut egui::Ui, dirty_level_object: &mut LevelObject) {
+    #[derive(Copy, Clone, PartialEq, Debug)]
+    enum Type {
+        Stationary,
+        Attached,
+        Radial,
+        ForwardCycle,
+        ForwardBackwardsCycle,
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Type::Stationary => write!(f, "Stationary"),
+                Type::Attached => write!(f, "Attached"),
+                Type::Radial => write!(f, "Radial"),
+                Type::ForwardCycle => write!(f, "Forward Cycle"),
+                Type::ForwardBackwardsCycle => write!(f, "Forward Backwards Cycle"),
+            }
+        }
+    }
+
+    let route_type = match dirty_level_object.route {
+        None => Type::Stationary,
+        Some(ObjectRoute {
+            desc: ObjectRouteDesc::Attached(_),
+            ..
+        }) => Type::Attached,
+        Some(ObjectRoute {
+            desc: ObjectRouteDesc::Radial(_),
+            ..
+        }) => Type::Radial,
+        Some(ObjectRoute {
+            desc: ObjectRouteDesc::ForwardCycle(_),
+            ..
+        }) => Type::ForwardCycle,
+        Some(ObjectRoute {
+            desc: ObjectRouteDesc::ForwardBackwardsCycle(_),
+            ..
+        }) => Type::ForwardBackwardsCycle,
+    };
+    let mut dirty_route_type = route_type;
+
+    egui::containers::ComboBox::from_label("")
+        .width(200.0)
+        .selected_text(route_type.to_string())
+        .show_ui(ui, |ui| {
+            ui.selectable_value(
+                &mut dirty_route_type,
+                Type::Stationary,
+                Type::Stationary.to_string(),
+            );
+            ui.selectable_value(
+                &mut dirty_route_type,
+                Type::Attached,
+                Type::Attached.to_string(),
+            );
+            ui.selectable_value(
+                &mut dirty_route_type,
+                Type::Radial,
+                Type::Radial.to_string(),
+            );
+            ui.selectable_value(
+                &mut dirty_route_type,
+                Type::ForwardCycle,
+                Type::ForwardCycle.to_string(),
+            );
+            ui.selectable_value(
+                &mut dirty_route_type,
+                Type::ForwardBackwardsCycle,
+                Type::ForwardBackwardsCycle.to_string(),
+            );
+        });
+
+    if route_type == dirty_route_type {
+        return;
+    }
+
+    let current_pivot_points = match &dirty_level_object.route {
+        None => vec![],
+        Some(ObjectRoute {
+            desc: ObjectRouteDesc::Attached(pivot_point) | ObjectRouteDesc::Radial(pivot_point),
+            ..
+        }) => {
+            let mut points = Vec::new();
+            if let Some(pivot_point) = pivot_point {
+                points.push(*pivot_point);
+            }
+            points
+        }
+        Some(ObjectRoute {
+            desc:
+                ObjectRouteDesc::ForwardCycle(pivot_points)
+                | ObjectRouteDesc::ForwardBackwardsCycle(pivot_points),
+            ..
+        }) => pivot_points.clone(),
+    };
+
+    match dirty_route_type {
+        Type::Stationary => {
+            dirty_level_object.route = None;
+        }
+        Type::Attached => {
+            replace_route_desc(
+                &mut dirty_level_object.route,
+                ObjectRouteDesc::Attached(current_pivot_points.get(0).cloned()),
+            );
+        }
+        Type::Radial => {
+            replace_route_desc(
+                &mut dirty_level_object.route,
+                ObjectRouteDesc::Radial(current_pivot_points.get(0).cloned()),
+            );
+        }
+        Type::ForwardCycle => {
+            replace_route_desc(
+                &mut dirty_level_object.route,
+                ObjectRouteDesc::ForwardCycle(current_pivot_points),
+            );
+        }
+        Type::ForwardBackwardsCycle => {
+            replace_route_desc(
+                &mut dirty_level_object.route,
+                ObjectRouteDesc::ForwardBackwardsCycle(current_pivot_points),
+            );
+        }
+    }
+}
+
+fn replace_route_desc(route: &mut Option<ObjectRoute>, desc: ObjectRouteDesc) {
+    if let Some(route) = route {
+        route.desc = desc;
+    } else {
+        *route = Some(ObjectRoute {
+            period: FrameNumber::new(SIMULATIONS_PER_SECOND * 10),
+            start_frame_offset: FrameNumber::new(0),
+            desc,
+        });
+    }
 }

--- a/libs/client_lib/src/ui/debug_ui.rs
+++ b/libs/client_lib/src/ui/debug_ui.rs
@@ -189,6 +189,7 @@ pub fn inspect_object(
             {
                 ui.label(format!("Player name: {}", player_name));
             }
+            ui.label(format!("{:?}", entity));
             if let Some(level_object_label) = queries
                 .objects_registry
                 .get_id(entity)

--- a/libs/client_lib/src/ui/debug_ui.rs
+++ b/libs/client_lib/src/ui/debug_ui.rs
@@ -11,7 +11,7 @@ use bevy_egui::{egui, EguiContext, EguiSettings};
 use mr_shared_lib::{
     framebuffer::FrameNumber,
     game::{
-        components::{PlayerDirection, Position},
+        components::{LevelObjectMovement, PlayerDirection, Position},
         level::LevelState,
     },
     messages::{EntityNetId, PlayerNetId},
@@ -161,6 +161,7 @@ pub struct InspectObjectQueries<'a> {
     level_state: Res<'a, LevelState>,
     positions: Query<'a, &'static Position>,
     player_directions: Query<'a, &'static PlayerDirection>,
+    level_object_movements: Query<'a, &'static LevelObjectMovement>,
 }
 
 pub fn inspect_object(
@@ -189,7 +190,7 @@ pub fn inspect_object(
             {
                 ui.label(format!("Player name: {}", player_name));
             }
-            ui.label(format!("{:?}", entity));
+            ui.label(format!("Entity: {:?}", entity));
             if let Some(level_object_label) = queries
                 .objects_registry
                 .get_id(entity)
@@ -197,6 +198,16 @@ pub fn inspect_object(
                 .map(|level_object| level_object.label.clone())
             {
                 ui.label(&level_object_label);
+            }
+            if let Ok(level_object_movement) = queries.level_object_movements.get(entity) {
+                ui.collapsing("Route", |ui| {
+                    ui.label(format!(
+                        "Frame started: {}",
+                        level_object_movement.frame_started
+                    ));
+                    ui.label(format!("Init vec: {}", level_object_movement.init_vec));
+                    ui.label(format!("Period: {}", level_object_movement.period));
+                });
             }
             if let Ok(position) = queries.positions.get(entity) {
                 position.inspect(ui);

--- a/libs/client_lib/src/ui/mod.rs
+++ b/libs/client_lib/src/ui/mod.rs
@@ -6,6 +6,8 @@ pub mod debug_ui;
 pub mod help_ui;
 pub mod overlay_ui;
 
+mod widgets;
+
 pub trait MuddleInspectable {
     fn inspect(&self, ui: &mut Ui);
 

--- a/libs/client_lib/src/ui/widgets/mod.rs
+++ b/libs/client_lib/src/ui/widgets/mod.rs
@@ -1,0 +1,1 @@
+pub mod sortable;

--- a/libs/client_lib/src/ui/widgets/sortable.rs
+++ b/libs/client_lib/src/ui/widgets/sortable.rs
@@ -1,0 +1,289 @@
+use bevy_egui::egui::{self, Id, Ui};
+use std::collections::HashSet;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ListItem<T> {
+    pub id: Id,
+    pub label: String,
+    pub data: T,
+    // Only first N and last N can be sortable.
+    pub sortable: bool,
+}
+
+#[derive(Clone, Default, Debug)]
+struct DraggedItemData(Option<DraggedItem>);
+
+#[derive(Clone, Debug)]
+struct DraggedItem {
+    id: Id,
+    initial_drag_pos: egui::Pos2,
+    initial_rect: egui::Rect,
+}
+
+#[derive(Clone, Debug)]
+struct SortableListData<T: Clone> {
+    list: Vec<ListItem<T>>,
+    dragged_item: Option<DraggedItem>,
+}
+
+impl<T: Clone> Default for SortableListData<T> {
+    fn default() -> Self {
+        Self {
+            list: Vec::new(),
+            dragged_item: None,
+        }
+    }
+}
+
+struct PaintItemJob {
+    rect: egui::Rect,
+    padding: egui::Vec2,
+    item_visuals: egui::style::WidgetVisuals,
+    label_galley: std::sync::Arc<egui::epaint::Galley>,
+    cross_galley: std::sync::Arc<egui::epaint::Galley>,
+    cross_color: egui::Color32,
+}
+
+impl PaintItemJob {
+    fn paint(self, ui: &mut Ui) {
+        let shrank_rect = self.rect.shrink2(self.padding);
+        let cross_rect = egui::Rect::from_min_size(
+            egui::Pos2::new(
+                shrank_rect.max.x - self.cross_galley.size.x - self.padding.x,
+                shrank_rect.min.y,
+            ),
+            self.cross_galley.size,
+        );
+
+        let label_cursor = ui
+            .layout()
+            .align_size_within_rect(self.label_galley.size, shrank_rect)
+            .min;
+
+        ui.painter().rect(
+            self.rect,
+            self.item_visuals.corner_radius,
+            self.item_visuals.bg_fill,
+            self.item_visuals.bg_stroke,
+        );
+        ui.painter()
+            .galley(label_cursor, self.label_galley, ui.visuals().text_color());
+        let cross_cursor = ui
+            .layout()
+            .align_size_within_rect(self.cross_galley.size, cross_rect)
+            .min;
+        ui.painter()
+            .galley(cross_cursor, self.cross_galley, self.cross_color);
+    }
+}
+
+pub fn sortable_list<
+    T: Clone + Send + Sync + Eq + std::hash::Hash + std::fmt::Debug + 'static,
+    I: std::hash::Hash,
+>(
+    ui: &mut Ui,
+    list_id: I,
+    list: &mut Vec<ListItem<T>>,
+) -> bool {
+    let first_unsortable_count = list
+        .iter()
+        .position(|item| item.sortable)
+        .unwrap_or(list.len());
+    let last_unsortable_count = list
+        .iter()
+        .rev()
+        .position(|item| item.sortable)
+        .unwrap_or(list.len());
+
+    if list.iter().enumerate().any(|(i, item)| {
+        !item.sortable && i >= first_unsortable_count && i < list.len() - last_unsortable_count
+    }) {
+        panic!("Gaps between sortable elements are not allowed");
+    }
+
+    let unique_ids = list.iter().map(|i| i.id).collect::<HashSet<_>>();
+    if unique_ids.len() != list.len() {
+        panic!("Sortable list elements must be unique");
+    }
+
+    let list_id = Id::new(list_id);
+    let mut memory = ui.memory();
+    let sortable_list_data = memory
+        .id_data_temp
+        .get_mut_or_default::<SortableListData<T>>(list_id);
+
+    let current_list_set = sortable_list_data
+        .list
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let list_set = list.iter().cloned().collect::<HashSet<_>>();
+    if current_list_set != list_set {
+        sortable_list_data.dragged_item = None;
+        sortable_list_data.list = list.clone();
+    }
+
+    let mut sortable_list_data = sortable_list_data.clone();
+    drop(memory);
+
+    let mut list_item_rects = Vec::new();
+
+    let cross_text = "❌";
+    let padding = ui.spacing().button_padding;
+    let available_width = ui.available_width();
+
+    let cross_galley = ui
+        .fonts()
+        .layout_no_wrap(egui::TextStyle::Button, cross_text.to_owned());
+    let total_extra = egui::Vec2::new(cross_galley.size.x, 0.0)
+        + padding * 2.0
+        + egui::Vec2::new(padding.x, 0.0) * 2.0;
+    let desired_size = egui::Vec2::new(available_width, cross_galley.size.y + total_extra.y);
+
+    let mut item_to_remove: Option<usize> = None;
+    let mut draggable_current_index: Option<usize> = None;
+    let mut delayed_paint_job: Option<PaintItemJob> = None;
+
+    for (i, list_item) in sortable_list_data.list.iter().enumerate() {
+        let (id, mut rect) = ui.allocate_space(desired_size);
+        list_item_rects.push(rect);
+
+        let mut is_dragged_item = sortable_list_data
+            .dragged_item
+            .as_ref()
+            .map_or(false, |item| item.id == list_item.id);
+
+        if is_dragged_item {
+            let dragged_item = sortable_list_data.dragged_item.as_ref().unwrap();
+            let rect_delta = dragged_item.initial_rect.min - rect.min;
+            let delta = ui.input().pointer.interact_pos().unwrap() - dragged_item.initial_drag_pos
+                + rect_delta;
+            rect.min += delta;
+            rect.max += delta;
+        }
+
+        if ui.clip_rect().intersects(rect) {
+            let sense = if list_item.sortable {
+                egui::Sense::click_and_drag()
+            } else {
+                egui::Sense::hover()
+            };
+
+            let label_galley = ui.fonts().layout_multiline(
+                egui::TextStyle::Button,
+                list_item.label.clone(),
+                available_width - total_extra.x,
+            );
+
+            let shrank_rect = rect.shrink2(padding);
+            let cross_rect = egui::Rect::from_min_size(
+                egui::Pos2::new(
+                    shrank_rect.max.x - cross_galley.size.x - padding.x,
+                    shrank_rect.min.y,
+                ),
+                cross_galley.size,
+            );
+            let cross_response = ui.interact(cross_rect, list_item.id.with("remove"), sense);
+            if cross_response.clicked() {
+                item_to_remove = Some(i);
+            }
+
+            let item_response = ui.interact(rect, id, sense);
+
+            let interacting_with_cross =
+                cross_response.dragged() || cross_response.hovered() || cross_response.clicked();
+
+            if !interacting_with_cross
+                && item_response.dragged()
+                && sortable_list_data.dragged_item.is_none()
+            {
+                is_dragged_item = true;
+                sortable_list_data.dragged_item = Some(DraggedItem {
+                    id: list_item.id,
+                    initial_drag_pos: ui.input().pointer.interact_pos().unwrap(),
+                    initial_rect: rect,
+                });
+            }
+
+            let item_visuals = if !list_item.sortable {
+                ui.style().visuals.widgets.noninteractive
+            } else if sortable_list_data.dragged_item.is_some() {
+                if is_dragged_item {
+                    ui.style().visuals.widgets.active
+                } else {
+                    ui.style().visuals.widgets.inactive
+                }
+            } else {
+                *ui.style().interact(&item_response)
+            };
+
+            let cross_color = if !list_item.sortable {
+                egui::Color32::from_rgb(80, 80, 80)
+            } else if cross_response.hovered() {
+                egui::Color32::from_rgb(200, 20, 20)
+            } else {
+                egui::Color32::from_rgb(140, 30, 30)
+            };
+
+            let paint_item_job = PaintItemJob {
+                rect,
+                padding,
+                item_visuals,
+                label_galley,
+                cross_galley: cross_galley.clone(),
+                cross_color,
+            };
+            if is_dragged_item {
+                draggable_current_index = Some(i);
+                delayed_paint_job = Some(paint_item_job);
+            } else {
+                paint_item_job.paint(ui);
+            }
+
+            if !interacting_with_cross && item_response.hovered() && list_item.sortable {
+                ui.output().cursor_icon = egui::CursorIcon::Grab;
+            }
+        }
+    }
+
+    if let Some(i) = item_to_remove {
+        sortable_list_data.list.remove(i);
+    }
+
+    if !ui.memory().is_anything_being_dragged() {
+        sortable_list_data.dragged_item = None;
+    }
+
+    if sortable_list_data.dragged_item.is_some() {
+        if let Some(delayed_paint_job) = delayed_paint_job {
+            let draggable_new_index = list_item_rects
+                .iter()
+                .position(|item_rect| item_rect.contains(delayed_paint_job.rect.center()));
+            if let Some((new_i, old_i)) = draggable_new_index.zip(draggable_current_index) {
+                if sortable_list_data.list[new_i].sortable {
+                    let item = sortable_list_data.list.remove(old_i);
+                    sortable_list_data.list.insert(new_i, item);
+                }
+            }
+
+            delayed_paint_job.paint(ui);
+        }
+
+        ui.output().cursor_icon = egui::CursorIcon::Grabbing;
+    }
+
+    ui.separator();
+
+    let mut edited = false;
+    if sortable_list_data.dragged_item.is_none() && *list != sortable_list_data.list {
+        *list = sortable_list_data.list.clone();
+        edited = true;
+    }
+
+    *ui.memory()
+        .id_data_temp
+        .get_mut::<SortableListData<T>>(&list_id)
+        .unwrap() = sortable_list_data;
+
+    edited
+}

--- a/libs/client_lib/src/ui/widgets/sortable.rs
+++ b/libs/client_lib/src/ui/widgets/sortable.rs
@@ -6,7 +6,6 @@ pub struct ListItem<T> {
     pub id: Id,
     pub label: String,
     pub data: T,
-    // Only first N and last N can be sortable.
     pub sortable: bool,
 }
 

--- a/libs/client_lib/src/visuals.rs
+++ b/libs/client_lib/src/visuals.rs
@@ -3,25 +3,30 @@ use bevy::{
     ecs::{
         entity::Entity,
         query::With,
-        system::{Local, Query, ResMut},
+        system::{Local, Query, QuerySet, ResMut},
     },
     render::draw::Visible,
 };
 use mr_shared_lib::{
     game::{
         client_factories::VisibilitySettings,
-        components::LevelObjectTag,
+        components::{LevelObjectStaticGhost, LevelObjectTag},
         level::{LevelObjectDesc, LevelParams},
     },
     player::PlayerRole,
 };
+
+pub type Queries<'a, 'b, 'c> = QuerySet<(
+    Query<'a, (Entity, &'b mut Visible), With<LevelObjectTag>>,
+    Query<'a, &'c mut Visible, With<LevelObjectStaticGhost>>,
+)>;
 
 pub fn control_builder_visibility(
     mut prev_role: Local<Option<PlayerRole>>,
     player_params: PlayerParams,
     level_params: LevelParams,
     mut visibility_settings: ResMut<VisibilitySettings>,
-    mut level_objects_query: Query<(Entity, &mut Visible), With<LevelObjectTag>>,
+    mut queries: Queries,
 ) {
     if let Some(player) = player_params.current_player() {
         if *prev_role == Some(player.role) {
@@ -29,20 +34,27 @@ pub fn control_builder_visibility(
         }
         *prev_role = Some(player.role);
 
-        let points_should_be_visible = match player.role {
+        let is_builder = match player.role {
             PlayerRole::Runner => false,
             PlayerRole::Builder => true,
         };
-        visibility_settings.route_points = points_should_be_visible;
+        visibility_settings.route_points = is_builder;
+        visibility_settings.ghosts = is_builder;
+
+        let level_objects_query = queries.q0_mut();
         for (entity, mut visible) in level_objects_query.iter_mut() {
             if let Some(level_object) = level_params.level_object_by_entity(entity) {
                 match level_object.desc {
                     LevelObjectDesc::RoutePoint(_) => {
-                        visible.is_visible = points_should_be_visible;
+                        visible.is_visible = is_builder;
                     }
                     LevelObjectDesc::Plane(_) | LevelObjectDesc::Cube(_) => {}
                 }
             }
+        }
+        let ghosts_query = queries.q1_mut();
+        for mut visible in ghosts_query.iter_mut() {
+            visible.is_visible = is_builder;
         }
     }
 }

--- a/libs/client_lib/src/visuals.rs
+++ b/libs/client_lib/src/visuals.rs
@@ -1,0 +1,48 @@
+use crate::helpers::PlayerParams;
+use bevy::{
+    ecs::{
+        entity::Entity,
+        query::With,
+        system::{Local, Query, ResMut},
+    },
+    render::draw::Visible,
+};
+use mr_shared_lib::{
+    game::{
+        client_factories::VisibilitySettings,
+        components::LevelObjectTag,
+        level::{LevelObjectDesc, LevelParams},
+    },
+    player::PlayerRole,
+};
+
+pub fn control_builder_visibility(
+    mut prev_role: Local<Option<PlayerRole>>,
+    player_params: PlayerParams,
+    level_params: LevelParams,
+    mut visibility_settings: ResMut<VisibilitySettings>,
+    mut level_objects_query: Query<(Entity, &mut Visible), With<LevelObjectTag>>,
+) {
+    if let Some(player) = player_params.current_player() {
+        if *prev_role == Some(player.role) {
+            return;
+        }
+        *prev_role = Some(player.role);
+
+        let pivots_should_be_visible = match player.role {
+            PlayerRole::Runner => false,
+            PlayerRole::Builder => true,
+        };
+        visibility_settings.pivot_points = pivots_should_be_visible;
+        for (entity, mut visible) in level_objects_query.iter_mut() {
+            if let Some(level_object) = level_params.level_object_by_entity(entity) {
+                match level_object.desc {
+                    LevelObjectDesc::PivotPoint(_) => {
+                        visible.is_visible = pivots_should_be_visible;
+                    }
+                    LevelObjectDesc::Plane(_) | LevelObjectDesc::Cube(_) => {}
+                }
+            }
+        }
+    }
+}

--- a/libs/client_lib/src/visuals.rs
+++ b/libs/client_lib/src/visuals.rs
@@ -29,16 +29,16 @@ pub fn control_builder_visibility(
         }
         *prev_role = Some(player.role);
 
-        let pivots_should_be_visible = match player.role {
+        let points_should_be_visible = match player.role {
             PlayerRole::Runner => false,
             PlayerRole::Builder => true,
         };
-        visibility_settings.pivot_points = pivots_should_be_visible;
+        visibility_settings.route_points = points_should_be_visible;
         for (entity, mut visible) in level_objects_query.iter_mut() {
             if let Some(level_object) = level_params.level_object_by_entity(entity) {
                 match level_object.desc {
-                    LevelObjectDesc::PivotPoint(_) => {
-                        visible.is_visible = pivots_should_be_visible;
+                    LevelObjectDesc::RoutePoint(_) => {
+                        visible.is_visible = points_should_be_visible;
                     }
                     LevelObjectDesc::Plane(_) | LevelObjectDesc::Cube(_) => {}
                 }

--- a/libs/client_lib/src/visuals.rs
+++ b/libs/client_lib/src/visuals.rs
@@ -30,8 +30,6 @@ pub fn control_builder_visibility(
     >,
 ) {
     if let Some(player) = player_params.current_player() {
-        *prev_role = Some(player.role);
-
         let is_builder = match player.role {
             PlayerRole::Runner => false,
             PlayerRole::Builder => true,
@@ -67,5 +65,7 @@ pub fn control_builder_visibility(
                 visible.is_visible = is_builder;
             }
         }
+
+        *prev_role = Some(player.role);
     }
 }

--- a/libs/server_lib/src/lib.rs
+++ b/libs/server_lib/src/lib.rs
@@ -95,6 +95,7 @@ pub fn init_level(
         frame_number: FrameNumber::new(0),
         object: LevelObject {
             net_id: entity_net_id_counter.increment(),
+            label: "Ground".to_owned(),
             desc: LevelObjectDesc::Plane(PlaneDesc {
                 position: Vec2::ZERO,
                 size: PLANE_SIZE,

--- a/libs/server_lib/src/lib.rs
+++ b/libs/server_lib/src/lib.rs
@@ -100,6 +100,7 @@ pub fn init_level(
                 position: Vec2::ZERO,
                 size: PLANE_SIZE,
             }),
+            route: None,
         },
     });
 }

--- a/libs/server_lib/src/net.rs
+++ b/libs/server_lib/src/net.rs
@@ -570,6 +570,9 @@ pub fn send_network_updates(
     players_registry: Res<EntityRegistry<PlayerNetId>>,
     mut deferred_message_queues: DeferredMessageQueues,
 ) {
+    // We run this system after we've concluded the simulation. As we don't have updates for the
+    // next frame yet, we decrement the frame number.
+    let time = time.prev_frame();
     log::trace!("Sending network updates (frame: {})", time.server_frame);
 
     broadcast_start_game_messages(
@@ -913,6 +916,9 @@ fn create_player_state(
                 direction,
             });
         }
+    }
+    if inputs.is_empty() && player_direction.buffer.len() > 1 {
+        log::error!("Missing updates for Player {} (updates start frame: {}, last player direction frame: {:?})", net_id.0, updates_start_frame, player_direction.buffer.end_frame());
     }
 
     let start_position_frame = inputs.first().map_or_else(

--- a/libs/server_lib/src/net.rs
+++ b/libs/server_lib/src/net.rs
@@ -854,7 +854,7 @@ fn broadcast_start_game_messages(
                     nickname: player.nickname.clone(),
                 })
                 .collect(),
-            generation: time.generation,
+            generation: time.server_generation,
             game_state: DeltaUpdate {
                 frame_number: time.server_frame,
                 acknowledgments: connection_state.incoming_acknowledgments(),

--- a/libs/server_lib/src/player_updates.rs
+++ b/libs/server_lib/src/player_updates.rs
@@ -177,9 +177,11 @@ pub fn process_spawn_level_object_requests(
                     }
                 }
             };
+            let net_id = entity_net_id_counter.increment();
             let spawn_level_object = UpdateLevelObject {
                 object: LevelObject {
-                    net_id: entity_net_id_counter.increment(),
+                    net_id,
+                    label: format!("{} {}", desc.label(), net_id.0),
                     desc,
                 },
                 frame_number: time.frame_number,

--- a/libs/server_lib/src/player_updates.rs
+++ b/libs/server_lib/src/player_updates.rs
@@ -183,6 +183,7 @@ pub fn process_spawn_level_object_requests(
                     net_id,
                     label: format!("{} {}", desc.label(), net_id.0),
                     desc,
+                    route: None,
                 },
                 frame_number: time.frame_number,
             };

--- a/libs/shared_lib/Cargo.toml
+++ b/libs/shared_lib/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-client = ["bevy/render"]
+client = ["bevy/render", "bevy_egui"]
 web = ["chrono/wasmbind"]
 
 [dependencies]
+bevy_egui = { version = "0.5.0", optional = true }
 bevy_networking_turbulence = { version = "0.2.0", default-features = false }
 bevy_rapier3d = { version = "0.10.2", features = ["wasm-bindgen"] }
 bincode = "1.3.1"

--- a/libs/shared_lib/src/client/materials.rs
+++ b/libs/shared_lib/src/client/materials.rs
@@ -1,0 +1,48 @@
+use bevy::{
+    asset::{Assets, Handle},
+    ecs::system::{Commands, ResMut},
+    prelude::StandardMaterial,
+    render::color::Color,
+};
+
+pub struct MuddleMaterials {
+    pub player: Handle<StandardMaterial>,
+    pub normal: ObjectMaterials,
+    pub ghost: ObjectMaterials,
+}
+
+pub fn init_object_materials(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let a = 0.5;
+    commands.insert_resource(MuddleMaterials {
+        player: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        normal: ObjectMaterials {
+            plane: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            cube: materials.add(Color::rgb(0.4, 0.4, 0.4).into()),
+            route_point: {
+                let mut material: StandardMaterial = Color::rgb(0.4, 0.4, 0.7).into();
+                material.reflectance = 0.0;
+                material.metallic = 0.0;
+                materials.add(material)
+            },
+        },
+        ghost: ObjectMaterials {
+            plane: materials.add(Color::rgba(0.3, 0.5, 0.3, a).into()),
+            cube: materials.add(Color::rgba(0.4, 0.4, 0.4, a).into()),
+            route_point: {
+                let mut material: StandardMaterial = Color::rgba(0.4, 0.4, 0.7, a).into();
+                material.reflectance = 0.0;
+                material.metallic = 0.0;
+                materials.add(material)
+            },
+        },
+    })
+}
+
+pub struct ObjectMaterials {
+    pub plane: Handle<StandardMaterial>,
+    pub cube: Handle<StandardMaterial>,
+    pub route_point: Handle<StandardMaterial>,
+}

--- a/libs/shared_lib/src/client/mod.rs
+++ b/libs/shared_lib/src/client/mod.rs
@@ -1,3 +1,5 @@
+pub mod materials;
+
 use bevy::{
     math::Vec3,
     render::{

--- a/libs/shared_lib/src/client/mod.rs
+++ b/libs/shared_lib/src/client/mod.rs
@@ -1,6 +1,9 @@
-use bevy::render::{
-    mesh::{Indices, Mesh},
-    pipeline::PrimitiveTopology,
+use bevy::{
+    math::Vec3,
+    render::{
+        mesh::{Indices, Mesh},
+        pipeline::PrimitiveTopology,
+    },
 };
 
 /// A square on the XZ plane.
@@ -43,6 +46,105 @@ impl From<XyPlane> for Mesh {
         mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Pyramid {
+    pub height: f32,
+    pub base_edge_half_len: f32,
+}
+
+impl Pyramid {
+    pub fn positions(&self) -> Vec<Vec3> {
+        let Self {
+            height,
+            base_edge_half_len,
+        } = *self;
+        vec![
+            // Bottom.
+            Vec3::new(-base_edge_half_len, -base_edge_half_len, 0.0),
+            Vec3::new(-base_edge_half_len, base_edge_half_len, 0.0),
+            Vec3::new(base_edge_half_len, base_edge_half_len, 0.0),
+            Vec3::new(base_edge_half_len, -base_edge_half_len, 0.0),
+            // West.
+            Vec3::new(-base_edge_half_len, base_edge_half_len, 0.0),
+            Vec3::new(-base_edge_half_len, -base_edge_half_len, 0.0),
+            Vec3::new(0.0, 0.0, height),
+            // North.
+            Vec3::new(base_edge_half_len, base_edge_half_len, 0.0),
+            Vec3::new(-base_edge_half_len, base_edge_half_len, 0.0),
+            Vec3::new(0.0, 0.0, height),
+            // East.
+            Vec3::new(base_edge_half_len, -base_edge_half_len, 0.0),
+            Vec3::new(base_edge_half_len, base_edge_half_len, 0.0),
+            Vec3::new(0.0, 0.0, height),
+            // South.
+            Vec3::new(-base_edge_half_len, -base_edge_half_len, 0.0),
+            Vec3::new(base_edge_half_len, -base_edge_half_len, 0.0),
+            Vec3::new(0.0, 0.0, height),
+        ]
+    }
+
+    #[rustfmt::skip]
+    pub fn indices(&self) -> Vec<u32> {
+        vec![
+            // Bottom 1.
+            0, 1, 3,
+            // Bottom 2.
+            1, 2, 3,
+            // West.
+            4, 5, 6,
+            // North.
+            7, 8, 9,
+            // East.
+            10, 11, 12,
+            // South.
+            13, 14, 15,
+        ]
+    }
+}
+
+impl From<Pyramid> for Mesh {
+    fn from(pyramid: Pyramid) -> Self {
+        let positions = pyramid.positions();
+        let indices = pyramid.indices();
+
+        let west_norm = (positions[0] - positions[1]).cross(positions[6] - positions[0]);
+        let north_norm = (positions[1] - positions[2]).cross(positions[6] - positions[1]);
+        let east_norm = (positions[2] - positions[3]).cross(positions[6] - positions[2]);
+        let south_norm = (positions[3] - positions[0]).cross(positions[6] - positions[3]);
+        let normals = vec![
+            Vec3::new(0.0, 0.0, -1.0),
+            Vec3::new(0.0, 0.0, -1.0),
+            Vec3::new(0.0, 0.0, -1.0),
+            Vec3::new(0.0, 0.0, -1.0),
+            west_norm,
+            west_norm,
+            west_norm,
+            north_norm,
+            north_norm,
+            north_norm,
+            east_norm,
+            east_norm,
+            east_norm,
+            south_norm,
+            south_norm,
+            south_norm,
+        ];
+
+        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        mesh.set_indices(Some(Indices::U32(indices)));
+        mesh.set_attribute(
+            Mesh::ATTRIBUTE_POSITION,
+            positions.iter().map(|p| *p.as_ref()).collect::<Vec<_>>(),
+        );
+        mesh.set_attribute(
+            Mesh::ATTRIBUTE_NORMAL,
+            normals.iter().map(|p| *p.as_ref()).collect::<Vec<_>>(),
+        );
+        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vec![[0.0, 0.0]; 16]);
         mesh
     }
 }

--- a/libs/shared_lib/src/framebuffer.rs
+++ b/libs/shared_lib/src/framebuffer.rs
@@ -97,6 +97,16 @@ impl<T> Framebuffer<T> {
         let frame_len = FrameNumber::new(self.buffer.len() as u16);
         frame_number + self.limit >= self.start_frame + frame_len
     }
+
+    pub fn take(&mut self) -> Self {
+        let buf = Framebuffer {
+            start_frame: self.start_frame,
+            buffer: std::mem::take(&mut self.buffer),
+            limit: self.limit,
+        };
+        self.start_frame = self.end_frame();
+        buf
+    }
 }
 
 impl<T: Default + std::fmt::Debug> Framebuffer<T> {

--- a/libs/shared_lib/src/game/client_factories.rs
+++ b/libs/shared_lib/src/game/client_factories.rs
@@ -113,14 +113,14 @@ impl<'a> ClientFactory<'a> for CubeClientFactory {
     }
 }
 
-pub const PIVOT_POINT_HEIGHT: f32 = 0.8;
-pub const PIVOT_POINT_BASE_EDGE_HALF_LEN: f32 = 0.25;
+pub const ROUTE_POINT_HEIGHT: f32 = 0.8;
+pub const ROUTE_POINT_BASE_EDGE_HALF_LEN: f32 = 0.25;
 
-pub struct PivotPointClientFactory;
+pub struct RoutePointClientFactory;
 
-impl<'a> ClientFactory<'a> for PivotPointClientFactory {
+impl<'a> ClientFactory<'a> for RoutePointClientFactory {
     type Dependencies = PbrClientParams<'a>;
-    type Input = PivotPointDesc;
+    type Input = RoutePointDesc;
 
     #[cfg(feature = "client")]
     fn insert_components(
@@ -133,12 +133,12 @@ impl<'a> ClientFactory<'a> for PivotPointClientFactory {
         material.metallic = 0.0;
         commands.insert_bundle(PbrBundle {
             visible: Visible {
-                is_visible: deps.visibility_settings.pivot_points,
+                is_visible: deps.visibility_settings.route_points,
                 is_transparent: false,
             },
             mesh: deps.meshes.add(Mesh::from(Pyramid {
-                height: PIVOT_POINT_HEIGHT,
-                base_edge_half_len: PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                height: ROUTE_POINT_HEIGHT,
+                base_edge_half_len: ROUTE_POINT_BASE_EDGE_HALF_LEN,
             })),
             material: deps.materials.add(material),
             ..Default::default()
@@ -155,7 +155,7 @@ impl<'a> ClientFactory<'a> for PivotPointClientFactory {
 #[cfg(feature = "client")]
 #[derive(Default)]
 pub struct VisibilitySettings {
-    pub pivot_points: bool,
+    pub route_points: bool,
 }
 
 #[cfg(feature = "client")]

--- a/libs/shared_lib/src/game/client_factories.rs
+++ b/libs/shared_lib/src/game/client_factories.rs
@@ -1,7 +1,7 @@
 use crate::game::level_objects::*;
 #[cfg(feature = "client")]
 use crate::{
-    client::XyPlane,
+    client::*,
     game::components::{PlayerFrameSimulated, PredictedPosition},
     PLAYER_SIZE,
 };
@@ -102,6 +102,41 @@ impl<'a> ClientFactory<'a> for CubeClientFactory {
                 size: cube_desc.size * 2.0,
             })),
             material: deps.materials.add(Color::rgb(0.4, 0.4, 0.4).into()),
+            ..Default::default()
+        });
+        commands.insert(PlayerFrameSimulated);
+    }
+
+    #[cfg(feature = "client")]
+    fn remove_components(commands: &mut EntityCommands) {
+        commands.remove_bundle::<PbrBundle>();
+    }
+}
+
+pub const PIVOT_POINT_HEIGHT: f32 = 0.8;
+pub const PIVOT_POINT_BASE_EDGE_HALF_LEN: f32 = 0.25;
+
+pub struct PivotPointClientFactory;
+
+impl<'a> ClientFactory<'a> for PivotPointClientFactory {
+    type Dependencies = PbrClientParams<'a>;
+    type Input = PivotPointDesc;
+
+    #[cfg(feature = "client")]
+    fn insert_components(
+        commands: &mut EntityCommands,
+        deps: &mut Self::Dependencies,
+        _: &Self::Input,
+    ) {
+        let mut material: StandardMaterial = Color::rgb(0.4, 0.4, 0.7).into();
+        material.reflectance = 0.0;
+        material.metallic = 0.0;
+        commands.insert_bundle(PbrBundle {
+            mesh: deps.meshes.add(Mesh::from(Pyramid {
+                height: PIVOT_POINT_HEIGHT,
+                base_edge_half_len: PIVOT_POINT_BASE_EDGE_HALF_LEN,
+            })),
+            material: deps.materials.add(material),
             ..Default::default()
         });
         commands.insert(PlayerFrameSimulated);

--- a/libs/shared_lib/src/game/client_factories.rs
+++ b/libs/shared_lib/src/game/client_factories.rs
@@ -87,7 +87,7 @@ impl<'a> ClientFactory<'a> for PlaneClientFactory {
                 } else {
                     true
                 },
-                is_transparent: false,
+                is_transparent: input.is_ghost,
             },
             mesh: deps.meshes.add(Mesh::from(XyPlane {
                 size: input.desc.size * 2.0 * ghost_size_multiplier,
@@ -129,7 +129,7 @@ impl<'a> ClientFactory<'a> for CubeClientFactory {
                 } else {
                     true
                 },
-                is_transparent: false,
+                is_transparent: input.is_ghost,
             },
             mesh: deps.meshes.add(Mesh::from(shape::Cube {
                 size: input.desc.size * 2.0 * ghost_size_multiplier,
@@ -177,7 +177,7 @@ impl<'a> ClientFactory<'a> for RoutePointClientFactory {
                 } else {
                     deps.visibility_settings.route_points
                 },
-                is_transparent: false,
+                is_transparent: input.is_ghost,
             },
             mesh: deps.meshes.add(Mesh::from(Pyramid {
                 height: ROUTE_POINT_HEIGHT * ghost_size_multiplier,

--- a/libs/shared_lib/src/game/client_factories.rs
+++ b/libs/shared_lib/src/game/client_factories.rs
@@ -1,7 +1,7 @@
 use crate::game::level_objects::*;
 #[cfg(feature = "client")]
 use crate::{
-    client::*,
+    client::{materials::MuddleMaterials, *},
     game::components::{PlayerFrameSimulated, PredictedPosition},
     GHOST_SIZE_MULTIPLIER, PLAYER_SIZE,
 };
@@ -42,7 +42,7 @@ impl<'a> ClientFactory<'a> for PlayerClientFactory {
             mesh: deps.meshes.add(Mesh::from(shape::Cube {
                 size: PLAYER_SIZE * 2.0,
             })),
-            material: deps.materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            material: deps.materials.player.clone(),
             ..Default::default()
         });
         commands.insert(PredictedPosition { value: *position });
@@ -74,7 +74,6 @@ impl<'a> ClientFactory<'a> for PlaneClientFactory {
         deps: &mut Self::Dependencies,
         input: &Self::Input,
     ) {
-        let a = if input.is_ghost { 0.5 } else { 1.0 };
         let ghost_size_multiplier = if input.is_ghost {
             GHOST_SIZE_MULTIPLIER
         } else {
@@ -92,7 +91,11 @@ impl<'a> ClientFactory<'a> for PlaneClientFactory {
             mesh: deps.meshes.add(Mesh::from(XyPlane {
                 size: input.desc.size * 2.0 * ghost_size_multiplier,
             })),
-            material: deps.materials.add(Color::rgba(0.3, 0.5, 0.3, a).into()),
+            material: if input.is_ghost {
+                deps.materials.ghost.plane.clone()
+            } else {
+                deps.materials.normal.plane.clone()
+            },
             ..Default::default()
         });
         commands.insert(PlayerFrameSimulated);
@@ -116,7 +119,6 @@ impl<'a> ClientFactory<'a> for CubeClientFactory {
         deps: &mut Self::Dependencies,
         input: &Self::Input,
     ) {
-        let a = if input.is_ghost { 0.5 } else { 1.0 };
         let ghost_size_multiplier = if input.is_ghost {
             GHOST_SIZE_MULTIPLIER
         } else {
@@ -134,7 +136,11 @@ impl<'a> ClientFactory<'a> for CubeClientFactory {
             mesh: deps.meshes.add(Mesh::from(shape::Cube {
                 size: input.desc.size * 2.0 * ghost_size_multiplier,
             })),
-            material: deps.materials.add(Color::rgba(0.4, 0.4, 0.4, a).into()),
+            material: if input.is_ghost {
+                deps.materials.ghost.cube.clone()
+            } else {
+                deps.materials.normal.cube.clone()
+            },
             ..Default::default()
         });
         commands.insert(PlayerFrameSimulated);
@@ -161,15 +167,11 @@ impl<'a> ClientFactory<'a> for RoutePointClientFactory {
         deps: &mut Self::Dependencies,
         input: &Self::Input,
     ) {
-        let a = if input.is_ghost { 0.5 } else { 1.0 };
         let ghost_size_multiplier = if input.is_ghost {
             GHOST_SIZE_MULTIPLIER
         } else {
             1.0
         };
-        let mut material: StandardMaterial = Color::rgba(0.4, 0.4, 0.7, a).into();
-        material.reflectance = 0.0;
-        material.metallic = 0.0;
         commands.insert_bundle(PbrBundle {
             visible: Visible {
                 is_visible: if input.is_ghost {
@@ -183,7 +185,11 @@ impl<'a> ClientFactory<'a> for RoutePointClientFactory {
                 height: ROUTE_POINT_HEIGHT * ghost_size_multiplier,
                 base_edge_half_len: ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_size_multiplier,
             })),
-            material: deps.materials.add(material),
+            material: if input.is_ghost {
+                deps.materials.ghost.route_point.clone()
+            } else {
+                deps.materials.normal.route_point.clone()
+            },
             ..Default::default()
         });
         commands.insert(PlayerFrameSimulated);
@@ -206,7 +212,7 @@ pub struct VisibilitySettings {
 #[derive(SystemParam)]
 pub struct PbrClientParams<'a> {
     meshes: ResMut<'a, Assets<Mesh>>,
-    materials: ResMut<'a, Assets<StandardMaterial>>,
+    materials: Res<'a, MuddleMaterials>,
     visibility_settings: Res<'a, VisibilitySettings>,
 }
 

--- a/libs/shared_lib/src/game/client_factories.rs
+++ b/libs/shared_lib/src/game/client_factories.rs
@@ -132,6 +132,10 @@ impl<'a> ClientFactory<'a> for PivotPointClientFactory {
         material.reflectance = 0.0;
         material.metallic = 0.0;
         commands.insert_bundle(PbrBundle {
+            visible: Visible {
+                is_visible: deps.visibility_settings.pivot_points,
+                is_transparent: false,
+            },
             mesh: deps.meshes.add(Mesh::from(Pyramid {
                 height: PIVOT_POINT_HEIGHT,
                 base_edge_half_len: PIVOT_POINT_BASE_EDGE_HALF_LEN,
@@ -149,10 +153,17 @@ impl<'a> ClientFactory<'a> for PivotPointClientFactory {
 }
 
 #[cfg(feature = "client")]
+#[derive(Default)]
+pub struct VisibilitySettings {
+    pub pivot_points: bool,
+}
+
+#[cfg(feature = "client")]
 #[derive(SystemParam)]
 pub struct PbrClientParams<'a> {
     meshes: ResMut<'a, Assets<Mesh>>,
     materials: ResMut<'a, Assets<StandardMaterial>>,
+    visibility_settings: Res<'a, VisibilitySettings>,
 }
 
 #[cfg(not(feature = "client"))]

--- a/libs/shared_lib/src/game/components.rs
+++ b/libs/shared_lib/src/game/components.rs
@@ -2,7 +2,7 @@ use crate::{
     framebuffer::{FrameNumber, Framebuffer},
     COMPONENT_FRAMEBUFFER_LIMIT,
 };
-use bevy::math::Vec2;
+use bevy::{ecs::entity::Entity, math::Vec2, utils::HashSet};
 use std::collections::VecDeque;
 
 // NOTE: After adding components for new archetypes, make sure that related entities are cleaned up
@@ -126,3 +126,173 @@ impl Spawned {
 
 /// Marks an entity to be simulated with using `SimulationTime::player_frame`.
 pub struct PlayerFrameSimulated;
+
+#[derive(Clone)]
+pub struct LevelObjectMovement {
+    /// May point to the future if it's the start of the game and we have non-zero start offset.
+    pub frame_started: FrameNumber,
+    /// Represents a vector from the attached route point to the initial object position.
+    /// Matters only for radial movement.
+    pub init_vec: Vec2,
+    /// Zero period means the object is always staying at the initial position or doesn't rotate.
+    pub period: FrameNumber,
+    /// How much route progress each point corresponds to. The final one must always equal `1.0`.
+    /// For the radial movement type it contains only 1 element: the attached object (the center).
+    pub points_progress: Vec<LevelObjectMovementPoint>,
+    pub movement_type: LevelObjectMovementType,
+}
+
+#[derive(Clone)]
+pub struct LevelObjectMovementPoint {
+    pub progress: f32,
+    pub position: Vec2,
+    pub entity: Entity,
+}
+
+/// Maps to `ObjectRouteDesc`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum LevelObjectMovementType {
+    /// Corresponds to either `ObjectRouteDesc::ForwardCycle` or `ObjectRouteDesc::ForwardBackwardsCycle`.
+    Linear,
+    /// If `LevelObjectMovement::period` equals 0, this corresponds to `ObjectRouteDesc::Attached`.
+    Radial,
+}
+
+impl LevelObjectMovement {
+    pub fn total_progress(&self, frame_number: FrameNumber) -> f32 {
+        if self.period == FrameNumber::new(0) {
+            return 0.0;
+        }
+
+        let frame_number = if self.frame_started > frame_number {
+            frame_number + self.period - self.frame_started
+        } else {
+            frame_number - self.frame_started
+        };
+        assert!(frame_number < self.period);
+
+        frame_number.value() as f32 / self.period.value() as f32
+    }
+
+    pub fn dependencies(&self) -> HashSet<Entity> {
+        self.points_progress
+            .iter()
+            .map(|point| point.entity)
+            .collect()
+    }
+
+    pub fn current_position(&self, frame_number: FrameNumber) -> Vec2 {
+        match self.movement_type {
+            LevelObjectMovementType::Linear => self.current_position_linear(frame_number),
+            LevelObjectMovementType::Radial => self.current_position_radial(frame_number),
+        }
+    }
+
+    fn current_position_linear(&self, frame_number: FrameNumber) -> Vec2 {
+        if self.points_progress.is_empty() {
+            return self.init_vec;
+        }
+        if self.points_progress.len() == 1 {
+            return self.points_progress[0].position;
+        }
+
+        let progress = self.total_progress(frame_number);
+        let mut current_point_progress = 0.0;
+        let mut next_point_progress = 0.0;
+        let mut next_point_index = 0usize;
+        for (i, point) in self.points_progress.iter().enumerate() {
+            if point.progress > progress {
+                next_point_index = i;
+                next_point_progress = point.progress;
+                break;
+            }
+            if point.progress - current_point_progress > f32::EPSILON {
+                current_point_progress = point.progress;
+            }
+        }
+
+        #[allow(clippy::float_cmp)]
+        if (progress - 1.0).abs() > f32::EPSILON {
+            assert_ne!(current_point_progress, next_point_progress);
+        } else {
+            return self.points_progress[next_point_index].position;
+        }
+        let progress_between_points =
+            1.0 - (next_point_progress - progress) / (next_point_progress - current_point_progress);
+
+        let current_point_position = self.points_progress[next_point_index - 1].position;
+        let next_point_position = self.points_progress[next_point_index].position;
+        current_point_position.lerp(next_point_position, progress_between_points)
+    }
+
+    fn current_position_radial(&self, frame_number: FrameNumber) -> Vec2 {
+        let center = self
+            .points_progress
+            .get(0)
+            .expect("Expected the first element of `points_progress` (the circle center) to exist")
+            .position;
+        let radius = rotate(
+            self.init_vec,
+            self.total_progress(frame_number) * std::f32::consts::PI * 2.0,
+        );
+        center + radius
+    }
+}
+
+fn rotate(v: Vec2, radians: f32) -> Vec2 {
+    Vec2::new(
+        v.x * radians.cos() - v.y * radians.sin(),
+        v.x * radians.sin() + v.y * radians.cos(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::math::Vec2;
+
+    fn assert_eq_vec(v1: Vec2, v2: Vec2) {
+        let v = (v1 - v2).abs();
+        assert!(v.x < f32::EPSILON && v.y < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_total_progress() {
+        let level_object_movement = LevelObjectMovement {
+            frame_started: FrameNumber::new(5),
+            init_vec: Vec2::ZERO,
+            period: FrameNumber::new(10),
+            points_progress: Vec::new(),
+            movement_type: LevelObjectMovementType::Linear,
+        };
+        assert!(
+            (level_object_movement.total_progress(FrameNumber::new(u16::MAX - 4)) - 0.0).abs()
+                < f32::EPSILON
+        );
+        assert!(
+            (level_object_movement.total_progress(FrameNumber::new(5)) - 0.0).abs() < f32::EPSILON
+        );
+        assert!(
+            (level_object_movement.total_progress(FrameNumber::new(0)) - 0.5).abs() < f32::EPSILON
+        );
+        assert!(
+            (level_object_movement.total_progress(FrameNumber::new(10)) - 0.5).abs() < f32::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_rotate() {
+        assert_eq_vec(
+            rotate(Vec2::new(1.0, 0.0), std::f32::consts::PI / 2.0),
+            Vec2::new(0.0, 1.0),
+        );
+        assert_eq_vec(
+            rotate(Vec2::new(0.0, 1.0), std::f32::consts::PI / 2.0),
+            Vec2::new(-1.0, 0.0),
+        );
+        assert_eq_vec(
+            rotate(Vec2::new(1.0, 0.0), std::f32::consts::PI),
+            Vec2::new(-1.0, 0.0),
+        );
+    }
+}

--- a/libs/shared_lib/src/game/components.rs
+++ b/libs/shared_lib/src/game/components.rs
@@ -84,15 +84,24 @@ impl Spawned {
 
     pub fn is_spawned(&self, frame_number: FrameNumber) -> bool {
         let mut res = true;
-        for (command, _) in self
+        let mut command_index: Option<usize> = None;
+        for (i, (command, _)) in self
             .commands
             .iter()
-            .take_while(|(_, command_frame_number)| frame_number >= *command_frame_number)
+            .enumerate()
+            .take_while(|(_, (_, command_frame_number))| frame_number >= *command_frame_number)
         {
+            command_index = Some(i);
             res = match command {
                 SpawnCommand::Spawn => true,
                 SpawnCommand::Despawn => false,
             }
+        }
+        // If there is the next command, and it's a Spawn command, the entity isn't spawned yet.
+        if let Some((SpawnCommand::Spawn, _)) =
+            self.commands.get(command_index.map_or(0, |i| i + 1))
+        {
+            return false;
         }
         res
     }

--- a/libs/shared_lib/src/game/components.rs
+++ b/libs/shared_lib/src/game/components.rs
@@ -43,6 +43,12 @@ impl Position {
         }
         Self { buffer }
     }
+
+    pub fn take(&mut self) -> Self {
+        Position {
+            buffer: self.buffer.take(),
+        }
+    }
 }
 
 /// Is used only by the client, to lerp the position if an authoritative update arrives from the

--- a/libs/shared_lib/src/game/components.rs
+++ b/libs/shared_lib/src/game/components.rs
@@ -14,6 +14,11 @@ pub struct LevelObjectTag;
 
 pub struct LevelObjectLabel(pub String);
 
+/// Represents a level object at its initial position.
+pub struct LevelObjectStaticGhost(pub Entity);
+
+pub struct LevelObjectStaticGhostParent(pub Entity);
+
 /// Represents Player's input (not an actual direction of entity's movement).
 pub struct PlayerDirection {
     /// `None` indicates a missing network input.

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -90,6 +90,10 @@ impl LevelObjectDesc {
         .to_owned()
     }
 
+    pub fn is_movable_with_mouse(&self) -> bool {
+        !matches!(self, Self::Plane(_))
+    }
+
     pub fn position(&self) -> Option<Vec2> {
         match self {
             Self::Plane(plane) => Some(plane.position),

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -1,10 +1,17 @@
-use crate::{game::level_objects::*, messages::EntityNetId};
+use crate::{
+    game::{
+        client_factories::{PIVOT_POINT_BASE_EDGE_HALF_LEN, PIVOT_POINT_HEIGHT},
+        level_objects::*,
+    },
+    messages::EntityNetId,
+};
 use bevy::math::Vec2;
 use bevy_rapier3d::{
     physics::{ColliderBundle, RigidBodyBundle},
     rapier::{
         dynamics::RigidBodyType,
         geometry::{ColliderShape, ColliderType},
+        math::Point,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -26,6 +33,7 @@ pub struct LevelObject {
 pub enum LevelObjectDesc {
     Plane(PlaneDesc),
     Cube(CubeDesc),
+    PivotPoint(PivotPointDesc),
 }
 
 impl LevelObjectDesc {
@@ -33,21 +41,24 @@ impl LevelObjectDesc {
         match self {
             Self::Plane(_) => "Plane",
             Self::Cube(_) => "Cube",
+            Self::PivotPoint(_) => "Pivot Point",
         }
         .to_owned()
     }
 
-    pub fn position(&self) -> Vec2 {
+    pub fn position(&self) -> Option<Vec2> {
         match self {
-            Self::Plane(plane) => plane.position,
-            Self::Cube(cube) => cube.position,
+            Self::Plane(plane) => Some(plane.position),
+            Self::Cube(cube) => Some(cube.position),
+            Self::PivotPoint(pivot_point) => Some(pivot_point.position),
         }
     }
 
-    pub fn position_mut(&mut self) -> &mut Vec2 {
+    pub fn position_mut(&mut self) -> Option<&mut Vec2> {
         match self {
-            Self::Plane(plane) => &mut plane.position,
-            Self::Cube(cube) => &mut cube.position,
+            Self::Plane(plane) => Some(&mut plane.position),
+            Self::Cube(cube) => Some(&mut cube.position),
+            Self::PivotPoint(pivot_point) => Some(&mut pivot_point.position),
         }
     }
 
@@ -56,7 +67,7 @@ impl LevelObjectDesc {
             Self::Plane(plane) => (
                 RigidBodyBundle {
                     body_type: RigidBodyType::KinematicPositionBased,
-                    position: [self.position().x, self.position().y, 0.0].into(),
+                    position: [self.position().unwrap().x, self.position().unwrap().y, 0.0].into(),
                     ..RigidBodyBundle::default()
                 },
                 ColliderBundle {
@@ -68,11 +79,51 @@ impl LevelObjectDesc {
             Self::Cube(cube) => (
                 RigidBodyBundle {
                     body_type: RigidBodyType::KinematicPositionBased,
-                    position: [self.position().x, self.position().y, cube.size].into(),
+                    position: [
+                        self.position().unwrap().x,
+                        self.position().unwrap().y,
+                        cube.size,
+                    ]
+                    .into(),
                     ..RigidBodyBundle::default()
                 },
                 ColliderBundle {
                     shape: ColliderShape::cuboid(cube.size, cube.size, cube.size),
+                    ..ColliderBundle::default()
+                },
+            ),
+            Self::PivotPoint(_) => (
+                RigidBodyBundle {
+                    body_type: RigidBodyType::KinematicPositionBased,
+                    position: [self.position().unwrap().x, self.position().unwrap().y, 0.0].into(),
+                    ..RigidBodyBundle::default()
+                },
+                ColliderBundle {
+                    collider_type: ColliderType::Sensor,
+                    shape: ColliderShape::convex_hull(&[
+                        Point::new(
+                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            0.0,
+                        ),
+                        Point::new(
+                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            0.0,
+                        ),
+                        Point::new(
+                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            0.0,
+                        ),
+                        Point::new(
+                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            0.0,
+                        ),
+                        Point::new(0.0, 0.0, PIVOT_POINT_HEIGHT),
+                    ])
+                    .unwrap(),
                     ..ColliderBundle::default()
                 },
             ),

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -4,8 +4,15 @@ use crate::{
         level_objects::*,
     },
     messages::EntityNetId,
+    registry::EntityRegistry,
 };
-use bevy::math::Vec2;
+use bevy::{
+    ecs::{
+        entity::Entity,
+        system::{Res, SystemParam},
+    },
+    math::Vec2,
+};
 use bevy_rapier3d::{
     physics::{ColliderBundle, RigidBodyBundle},
     rapier::{
@@ -16,6 +23,24 @@ use bevy_rapier3d::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+#[derive(SystemParam)]
+pub struct LevelParams<'a> {
+    pub level_state: Res<'a, LevelState>,
+    pub entity_registry: Res<'a, EntityRegistry<EntityNetId>>,
+}
+
+impl<'a> LevelParams<'a> {
+    pub fn level_object_by_entity(&self, entity: Entity) -> Option<&LevelObject> {
+        self.entity_registry
+            .get_id(entity)
+            .and_then(|net_id| self.level_object_by_net_id(net_id))
+    }
+
+    pub fn level_object_by_net_id(&self, entity_net_id: EntityNetId) -> Option<&LevelObject> {
+        self.level_state.objects.get(&entity_net_id)
+    }
+}
 
 #[derive(Default)]
 pub struct LevelState {

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -18,6 +18,7 @@ pub struct LevelState {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct LevelObject {
     pub net_id: EntityNetId,
+    pub label: String,
     pub desc: LevelObjectDesc,
 }
 

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -1,7 +1,7 @@
 use crate::{
     framebuffer::FrameNumber,
     game::{
-        client_factories::{PIVOT_POINT_BASE_EDGE_HALF_LEN, PIVOT_POINT_HEIGHT},
+        client_factories::{ROUTE_POINT_BASE_EDGE_HALF_LEN, ROUTE_POINT_HEIGHT},
         level_objects::*,
     },
     messages::EntityNetId,
@@ -76,7 +76,7 @@ pub enum ObjectRouteDesc {
 pub enum LevelObjectDesc {
     Plane(PlaneDesc),
     Cube(CubeDesc),
-    PivotPoint(PivotPointDesc),
+    RoutePoint(RoutePointDesc),
 }
 
 impl LevelObjectDesc {
@@ -84,7 +84,7 @@ impl LevelObjectDesc {
         match self {
             Self::Plane(_) => "Plane",
             Self::Cube(_) => "Cube",
-            Self::PivotPoint(_) => "Pivot Point",
+            Self::RoutePoint(_) => "Route Point",
         }
         .to_owned()
     }
@@ -93,7 +93,7 @@ impl LevelObjectDesc {
         match self {
             Self::Plane(plane) => Some(plane.position),
             Self::Cube(cube) => Some(cube.position),
-            Self::PivotPoint(pivot_point) => Some(pivot_point.position),
+            Self::RoutePoint(route_point) => Some(route_point.position),
         }
     }
 
@@ -101,7 +101,7 @@ impl LevelObjectDesc {
         match self {
             Self::Plane(plane) => Some(&mut plane.position),
             Self::Cube(cube) => Some(&mut cube.position),
-            Self::PivotPoint(pivot_point) => Some(&mut pivot_point.position),
+            Self::RoutePoint(route_point) => Some(&mut route_point.position),
         }
     }
 
@@ -135,7 +135,7 @@ impl LevelObjectDesc {
                     ..ColliderBundle::default()
                 },
             ),
-            Self::PivotPoint(_) => (
+            Self::RoutePoint(_) => (
                 RigidBodyBundle {
                     body_type: RigidBodyType::KinematicPositionBased,
                     position: [self.position().unwrap().x, self.position().unwrap().y, 0.0].into(),
@@ -145,26 +145,26 @@ impl LevelObjectDesc {
                     collider_type: ColliderType::Sensor,
                     shape: ColliderShape::convex_hull(&[
                         Point::new(
-                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
-                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
                             0.0,
                         ),
                         Point::new(
-                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
-                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
                             0.0,
                         ),
                         Point::new(
-                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
-                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
                             0.0,
                         ),
                         Point::new(
-                            PIVOT_POINT_BASE_EDGE_HALF_LEN,
-                            -PIVOT_POINT_BASE_EDGE_HALF_LEN,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
                             0.0,
                         ),
-                        Point::new(0.0, 0.0, PIVOT_POINT_HEIGHT),
+                        Point::new(0.0, 0.0, ROUTE_POINT_HEIGHT),
                     ])
                     .unwrap(),
                     ..ColliderBundle::default()

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -1,4 +1,5 @@
 use crate::{
+    framebuffer::FrameNumber,
     game::{
         client_factories::{PIVOT_POINT_BASE_EDGE_HALF_LEN, PIVOT_POINT_HEIGHT},
         level_objects::*,
@@ -52,6 +53,23 @@ pub struct LevelObject {
     pub net_id: EntityNetId,
     pub label: String,
     pub desc: LevelObjectDesc,
+    /// Absence of this field means that an object is stationary.
+    pub route: Option<ObjectRoute>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ObjectRoute {
+    pub period: FrameNumber,
+    pub start_frame_offset: FrameNumber,
+    pub desc: ObjectRouteDesc,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum ObjectRouteDesc {
+    Attached(Option<EntityNetId>),
+    Radial(Option<EntityNetId>),
+    ForwardCycle(Vec<EntityNetId>),
+    ForwardBackwardsCycle(Vec<EntityNetId>),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/libs/shared_lib/src/game/level.rs
+++ b/libs/shared_lib/src/game/level.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     messages::EntityNetId,
     registry::EntityRegistry,
+    GHOST_SIZE_MULTIPLIER,
 };
 use bevy::{
     ecs::{
@@ -105,7 +106,8 @@ impl LevelObjectDesc {
         }
     }
 
-    pub fn physics_body(&self) -> (RigidBodyBundle, ColliderBundle) {
+    pub fn physics_body(&self, is_ghost: bool) -> (RigidBodyBundle, ColliderBundle) {
+        let ghost_multiplier = if is_ghost { GHOST_SIZE_MULTIPLIER } else { 1.0 };
         match self {
             Self::Plane(plane) => (
                 RigidBodyBundle {
@@ -115,7 +117,11 @@ impl LevelObjectDesc {
                 },
                 ColliderBundle {
                     collider_type: ColliderType::Sensor,
-                    shape: ColliderShape::cuboid(plane.size, plane.size, 0.01),
+                    shape: ColliderShape::cuboid(
+                        plane.size * ghost_multiplier,
+                        plane.size * ghost_multiplier,
+                        0.01 * ghost_multiplier,
+                    ),
                     ..ColliderBundle::default()
                 },
             ),
@@ -131,7 +137,16 @@ impl LevelObjectDesc {
                     ..RigidBodyBundle::default()
                 },
                 ColliderBundle {
-                    shape: ColliderShape::cuboid(cube.size, cube.size, cube.size),
+                    collider_type: if is_ghost {
+                        ColliderType::Sensor
+                    } else {
+                        ColliderType::Solid
+                    },
+                    shape: ColliderShape::cuboid(
+                        cube.size * ghost_multiplier,
+                        cube.size * ghost_multiplier,
+                        cube.size * ghost_multiplier,
+                    ),
                     ..ColliderBundle::default()
                 },
             ),
@@ -145,26 +160,26 @@ impl LevelObjectDesc {
                     collider_type: ColliderType::Sensor,
                     shape: ColliderShape::convex_hull(&[
                         Point::new(
-                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
-                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
                             0.0,
                         ),
                         Point::new(
-                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
-                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
                             0.0,
                         ),
                         Point::new(
-                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
-                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
                             0.0,
                         ),
                         Point::new(
-                            ROUTE_POINT_BASE_EDGE_HALF_LEN,
-                            -ROUTE_POINT_BASE_EDGE_HALF_LEN,
+                            ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
+                            -ROUTE_POINT_BASE_EDGE_HALF_LEN * ghost_multiplier,
                             0.0,
                         ),
-                        Point::new(0.0, 0.0, ROUTE_POINT_HEIGHT),
+                        Point::new(0.0, 0.0, ROUTE_POINT_HEIGHT * ghost_multiplier),
                     ])
                     .unwrap(),
                     ..ColliderBundle::default()

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -14,6 +14,6 @@ pub struct CubeDesc {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct PivotPointDesc {
+pub struct RoutePointDesc {
     pub position: Vec2,
 }

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -58,11 +58,12 @@ pub fn update_level_object_movement_route_settings(
         .iter_mut()
         .filter(|(_, _, _, spawned)| spawned.is_spawned(time.player_frame))
     {
-        let level_def = level
-            .objects
-            .get(&objects_registry.get_id(entity).unwrap())
-            .unwrap()
-            .clone();
+        let level_def = match level.objects.get(&objects_registry.get_id(entity).unwrap()) {
+            Some(level_def) => level_def.clone(),
+            // The object is might be removed from the level when we are rewinding to the frame
+            // when it still existed. We can skip it, it's not the end of the world.
+            None => continue,
+        };
 
         let initial_object_position = level_def
             .desc

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -120,10 +120,12 @@ pub fn update_level_object_movement_route_settings(
                     let attached_point = level
                         .objects
                         .get(&objects_registry.get_id(points_progress[0].entity).unwrap())
-                        .unwrap()
-                        .desc
-                        .position()
-                        .expect("Object without a position can't be an attachable point");
+                        .map_or(initial_object_position, |level_object| {
+                            level_object
+                                .desc
+                                .position()
+                                .expect("Object without a position can't be an attachable point")
+                        });
                     initial_object_position - attached_point
                 }
                 LevelObjectMovementType::Linear => Vec2::ZERO,

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -368,6 +368,10 @@ fn closest_start_frame_to_time(
     start_frame_offset: FrameNumber,
     period: FrameNumber,
 ) -> FrameNumber {
+    if period == FrameNumber::new(0) {
+        return frame_number;
+    }
+
     assert!(start_frame_offset.value() < period.value()); // TODO! make sure we don't allow that in the UI.
     if generation == 0 && frame_number.value() < start_frame_offset.value() {
         return start_frame_offset;

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -1,4 +1,25 @@
-use bevy::math::Vec2;
+use crate::{
+    framebuffer::FrameNumber,
+    game::{
+        components::{
+            LevelObjectMovement, LevelObjectMovementPoint, LevelObjectMovementType, LevelObjectTag,
+            Position, Spawned,
+        },
+        level::{LevelState, ObjectRouteDesc},
+    },
+    messages::EntityNetId,
+    registry::EntityRegistry,
+    SimulationTime,
+};
+use bevy::{
+    ecs::{
+        entity::Entity,
+        query::With,
+        system::{Commands, Query, QuerySet, Res},
+    },
+    math::Vec2,
+    utils::HashMap,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -16,4 +37,471 @@ pub struct CubeDesc {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct RoutePointDesc {
     pub position: Vec2,
+}
+
+pub fn update_level_object_movement_route_settings(
+    mut commands: Commands,
+    time: Res<SimulationTime>,
+    level: Res<LevelState>,
+    objects_registry: Res<EntityRegistry<EntityNetId>>,
+    mut level_objects: Query<
+        (
+            Entity,
+            Option<&mut LevelObjectMovement>,
+            &mut Position,
+            &Spawned,
+        ),
+        With<LevelObjectTag>,
+    >,
+) {
+    for (entity, movement, mut position, _) in level_objects
+        .iter_mut()
+        .filter(|(_, _, _, spawned)| spawned.is_spawned(time.player_frame))
+    {
+        let level_def = level
+            .objects
+            .get(&objects_registry.get_id(entity).unwrap())
+            .unwrap()
+            .clone();
+
+        let initial_object_position = level_def
+            .desc
+            .position()
+            .expect("Objects without a position are not yet supported");
+
+        let mut is_invalid = false;
+        let new_level_object_movement = level_def.route.and_then(|route| {
+            let (movement_type, points) = match route.desc {
+                ObjectRouteDesc::Attached(None) | ObjectRouteDesc::Radial(None) => return None,
+                ObjectRouteDesc::Attached(Some(point)) | ObjectRouteDesc::Radial(Some(point)) => {
+                    (LevelObjectMovementType::Radial, vec![point])
+                }
+                ObjectRouteDesc::ForwardCycle(mut points) => {
+                    if points.is_empty() {
+                        return None;
+                    }
+                    let first_point = points.first().cloned().unwrap();
+                    points.push(first_point);
+                    (LevelObjectMovementType::Linear, points)
+                }
+                ObjectRouteDesc::ForwardBackwardsCycle(mut points) => {
+                    if points.is_empty() {
+                        return None;
+                    }
+                    let mut cycle = points.iter().rev().skip(1).cloned().collect::<Vec<_>>();
+                    points.append(&mut cycle);
+                    (LevelObjectMovementType::Linear, points)
+                }
+            };
+
+            let has_invalid_point = points
+                .iter()
+                .any(|point| objects_registry.get_entity(*point).is_none());
+            if has_invalid_point {
+                is_invalid = true;
+                return None;
+            }
+
+            let frame_started = closest_start_frame_to_time(
+                time.player_generation,
+                time.player_frame,
+                route.start_frame_offset,
+                route.period,
+            );
+            let mut points_progress = points
+                .into_iter()
+                .map(|point| LevelObjectMovementPoint {
+                    progress: 0.0,
+                    position: Vec2::ZERO,
+                    entity: objects_registry.get_entity(point).unwrap(),
+                })
+                .collect::<Vec<_>>();
+            points_progress.last_mut().unwrap().progress = 1.0;
+            let init_vec = match movement_type {
+                LevelObjectMovementType::Radial => {
+                    let attached_point = level
+                        .objects
+                        .get(&objects_registry.get_id(points_progress[0].entity).unwrap())
+                        .unwrap()
+                        .desc
+                        .position()
+                        .expect("Object without a position can't be an attachable point");
+                    initial_object_position - attached_point
+                }
+                LevelObjectMovementType::Linear => Vec2::ZERO,
+            };
+            Some(LevelObjectMovement {
+                frame_started,
+                init_vec,
+                period: route.period,
+                points_progress,
+                movement_type,
+            })
+        });
+
+        if is_invalid {
+            continue;
+        }
+
+        let needs_updating = match (new_level_object_movement.as_ref(), movement.as_deref()) {
+            (None, None) => false,
+            (
+                Some(LevelObjectMovement {
+                    frame_started,
+                    init_vec,
+                    period,
+                    points_progress,
+                    movement_type,
+                }),
+                Some(movement),
+            ) => {
+                let mut yes = *frame_started != movement.frame_started
+                    || *period != movement.period
+                    || *init_vec != movement.init_vec
+                    || *movement_type != movement.movement_type;
+
+                if !yes && points_progress.len() != movement.points_progress.len() {
+                    yes = true;
+                }
+
+                if !yes {
+                    for (p1, p2) in points_progress.iter().zip(movement.points_progress.iter()) {
+                        if p1.entity != p2.entity {
+                            yes = true;
+                            break;
+                        }
+                    }
+                }
+
+                yes
+            }
+            _ => true,
+        };
+
+        if needs_updating {
+            if let Some(new_level_object_movement) = new_level_object_movement {
+                commands.entity(entity).insert(new_level_object_movement);
+            } else {
+                commands.entity(entity).remove::<LevelObjectMovement>();
+                position
+                    .buffer
+                    .insert(time.player_frame, initial_object_position);
+            }
+        }
+    }
+}
+
+type LevelObjectsQuerySet<'a, 'b, 'c> = QuerySet<(
+    Query<
+        'a,
+        (
+            &'b mut Position,
+            Option<&'b mut LevelObjectMovement>,
+            &'b Spawned,
+        ),
+        With<LevelObjectTag>,
+    >,
+    Query<
+        'a,
+        (
+            Entity,
+            &'c Position,
+            Option<&'c LevelObjectMovement>,
+            &'c Spawned,
+        ),
+        With<LevelObjectTag>,
+    >,
+)>;
+
+pub fn process_objects_route_graph(
+    time: Res<SimulationTime>,
+    mut level_objects: LevelObjectsQuerySet,
+) {
+    let mut new_positions = HashMap::<Entity, (Vec2, Vec<LevelObjectMovementPoint>)>::default();
+    let level_objects_readonly = level_objects.q1();
+    for (entity, _, _, _) in level_objects_readonly.iter() {
+        resolve_new_path_recursive(
+            &time,
+            vec![entity],
+            level_objects_readonly,
+            &mut new_positions,
+        );
+    }
+
+    let level_objects = level_objects.q0_mut();
+    for (entity, (new_position, points_progress)) in new_positions {
+        let (mut position, movement, _) = level_objects.get_mut(entity).unwrap();
+        position.buffer.insert(time.player_frame, new_position);
+        if let Some(mut movement) = movement {
+            assert_eq!(movement.points_progress.len(), points_progress.len());
+            movement.points_progress = points_progress;
+        }
+    }
+}
+
+fn resolve_new_path_recursive(
+    time: &Res<SimulationTime>,
+    entities_stack: Vec<Entity>,
+    level_objects: &Query<
+        (Entity, &Position, Option<&LevelObjectMovement>, &Spawned),
+        With<LevelObjectTag>,
+    >,
+    object_updates: &mut HashMap<Entity, (Vec2, Vec<LevelObjectMovementPoint>)>,
+) {
+    let entity = *entities_stack.last().unwrap();
+    let (_entity, _position, movement, spawned): (
+        Entity,
+        &Position,
+        Option<&LevelObjectMovement>,
+        &Spawned,
+    ) = level_objects.get(entity).unwrap();
+
+    if !spawned.is_spawned(time.player_frame) {
+        return;
+    }
+
+    if object_updates.contains_key(&entity) {
+        return;
+    }
+
+    let movement = match movement {
+        Some(movement) => movement,
+        None => {
+            return;
+        }
+    };
+
+    let dependencies = movement.dependencies();
+    for dependency in dependencies {
+        let is_spawned = level_objects
+            .get_component::<Spawned>(dependency)
+            .map_or(false, |spawned| spawned.is_spawned(time.player_frame));
+        if entities_stack.contains(&dependency) || !is_spawned {
+            return;
+        }
+        let mut new_stack = entities_stack.clone();
+        new_stack.push(dependency);
+        resolve_new_path_recursive(time, new_stack, level_objects, object_updates);
+    }
+
+    #[allow(clippy::float_cmp)]
+    let points_progress = if movement.points_progress.len() == 1 {
+        let mut point = movement.points_progress[0].clone();
+        assert_eq!(point.progress, 1.0f32);
+        point.position = object_updates.get(&point.entity).map_or_else(
+            || {
+                *level_objects
+                    .get_component::<Position>(point.entity)
+                    .unwrap()
+                    .buffer
+                    .get(time.player_frame)
+                    .unwrap()
+            },
+            |(position, _)| *position,
+        );
+        vec![point]
+    } else {
+        // This can currently work only under the assumption that only linear movement can have
+        // more than 1 route point.
+        assert_eq!(movement.movement_type, LevelObjectMovementType::Linear);
+
+        let mut points_progress = Vec::new();
+        let mut total_distance = 0.0;
+        let mut prev_point_position = movement
+            .points_progress
+            .first()
+            .map_or(Vec2::ZERO, |point| point.position);
+        for point in &movement.points_progress {
+            let position: Vec2 = object_updates.get(&point.entity).map_or_else(
+                || {
+                    *level_objects
+                        .get_component::<Position>(point.entity)
+                        .unwrap()
+                        .buffer
+                        .get(time.player_frame)
+                        .unwrap()
+                },
+                |(position, _)| *position,
+            );
+            total_distance += (position - prev_point_position).length();
+            prev_point_position = position;
+
+            points_progress.push(LevelObjectMovementPoint {
+                progress: 0.0,
+                position,
+                entity: point.entity,
+            });
+        }
+        let mut current_distance = 0.0;
+        let mut prev_point_position = movement
+            .points_progress
+            .first()
+            .map_or(Vec2::ZERO, |point| point.position);
+        for i in 1..points_progress.len() - 1 {
+            let point = points_progress.get_mut(i).unwrap();
+            current_distance += (point.position - prev_point_position).length();
+            prev_point_position = point.position;
+            point.progress = current_distance / total_distance;
+        }
+        points_progress.last_mut().unwrap().progress = 1.0;
+
+        points_progress
+    };
+
+    let movement = LevelObjectMovement {
+        points_progress,
+        ..movement.clone()
+    };
+
+    object_updates.insert(
+        entity,
+        (
+            movement.current_position(time.player_frame),
+            movement.points_progress,
+        ),
+    );
+}
+
+fn closest_start_frame_to_time(
+    generation: u64,
+    frame_number: FrameNumber,
+    start_frame_offset: FrameNumber,
+    period: FrameNumber,
+) -> FrameNumber {
+    assert!(start_frame_offset.value() < period.value()); // TODO! make sure we don't allow that in the UI.
+    if generation == 0 && frame_number.value() < start_frame_offset.value() {
+        return start_frame_offset;
+    }
+
+    let mut result = start_frame_offset;
+    let runs_per_generation = u16::MAX / period.value();
+    for _ in 0..generation {
+        let (r, overflown) = result.add(FrameNumber::new(runs_per_generation * period.value()));
+        result = if overflown { r } else { r + period }
+    }
+
+    if frame_number.value() < result.value() {
+        let d = result.value() - frame_number.value();
+        let d_runs = d / period.value();
+        let d_remainder = d % period.value();
+        result -= FrameNumber::new(period.value() * d_runs);
+        if d_remainder > 0 {
+            result -= period;
+        }
+    } else {
+        let d = frame_number.value() - result.value();
+        let d_runs = d / period.value();
+        result += FrameNumber::new(period.value() * d_runs);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_closest_start_frame_to_time_zero_generation_less_than_period() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                0,
+                FrameNumber::new(0),
+                FrameNumber::new(3),
+                FrameNumber::new(10),
+            ),
+            FrameNumber::new(3)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_zero_generation_equals_offset() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                0,
+                FrameNumber::new(3),
+                FrameNumber::new(3),
+                FrameNumber::new(10),
+            ),
+            FrameNumber::new(3)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_zero_generation_close() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                0,
+                FrameNumber::new(15),
+                FrameNumber::new(3),
+                FrameNumber::new(10),
+            ),
+            FrameNumber::new(13)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_zero_generation_several_periods_away() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                0,
+                FrameNumber::new(40),
+                FrameNumber::new(3),
+                FrameNumber::new(10),
+            ),
+            FrameNumber::new(33)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_zero_generation_several_periods_away_start() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                0,
+                FrameNumber::new(43),
+                FrameNumber::new(3),
+                FrameNumber::new(10),
+            ),
+            FrameNumber::new(43)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_reach_generation_without_overflow() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                1,
+                FrameNumber::new(0),
+                FrameNumber::new(3),
+                FrameNumber::new(10000),
+            ),
+            FrameNumber::new(60003)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_reach_generation_with_overflow() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                1,
+                FrameNumber::new(5000),
+                FrameNumber::new(10000),
+                FrameNumber::new(20000),
+            ),
+            FrameNumber::new(4464)
+        );
+    }
+
+    #[test]
+    fn test_closest_start_frame_to_time_several_generations_away() {
+        assert_eq!(
+            closest_start_frame_to_time(
+                1,
+                FrameNumber::new(5000),
+                FrameNumber::new(10000),
+                FrameNumber::new(20000),
+            ),
+            FrameNumber::new(4464)
+        );
+    }
 }

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -76,12 +76,10 @@ pub fn update_level_object_movement_route_settings(
                 ObjectRouteDesc::Attached(Some(point)) | ObjectRouteDesc::Radial(Some(point)) => {
                     (LevelObjectMovementType::Radial, vec![point])
                 }
-                ObjectRouteDesc::ForwardCycle(mut points) => {
+                ObjectRouteDesc::ForwardCycle(points) => {
                     if points.is_empty() {
                         return None;
                     }
-                    let first_point = points.first().cloned().unwrap();
-                    points.push(first_point);
                     (LevelObjectMovementType::Linear, points)
                 }
                 ObjectRouteDesc::ForwardBackwardsCycle(mut points) => {

--- a/libs/shared_lib/src/game/level_objects.rs
+++ b/libs/shared_lib/src/game/level_objects.rs
@@ -12,3 +12,8 @@ pub struct CubeDesc {
     pub size: f32,
     pub position: Vec2,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PivotPointDesc {
+    pub position: Vec2,
+}

--- a/libs/shared_lib/src/game/mod.rs
+++ b/libs/shared_lib/src/game/mod.rs
@@ -1,7 +1,10 @@
 use crate::{
-    game::commands::{
-        DeferredQueue, DespawnLevelObject, DespawnPlayer, RestartGame, SpawnPlayer,
-        SwitchPlayerRole, UpdateLevelObject,
+    game::{
+        commands::{
+            DeferredQueue, DespawnLevelObject, DespawnPlayer, RestartGame, SpawnPlayer,
+            SwitchPlayerRole, UpdateLevelObject,
+        },
+        components::LevelObjectStaticGhost,
     },
     messages::{DeferredMessagesQueue, EntityNetId, PlayerNetId, SwitchRole},
     player::{Player, PlayerRole, PlayerUpdates},
@@ -10,6 +13,8 @@ use crate::{
 };
 use bevy::{
     ecs::{
+        entity::Entity,
+        query::With,
         system::{Res, ResMut},
         world::World,
     },
@@ -68,6 +73,13 @@ pub fn restart_game(world: &mut World) {
         entities_to_despawn.push(*object_entity);
     }
     objects_registry.clear();
+
+    for ghost_entity in world
+        .query_filtered::<Entity, With<LevelObjectStaticGhost>>()
+        .iter(world)
+    {
+        entities_to_despawn.push(ghost_entity);
+    }
 
     for entity in entities_to_despawn {
         world.despawn(entity);

--- a/libs/shared_lib/src/game/movement.rs
+++ b/libs/shared_lib/src/game/movement.rs
@@ -156,7 +156,7 @@ pub fn player_movement(time: Res<SimulationTime>, mut players: Query<PlayersQuer
             panic!(
                 "Expected player (entity: {:?}) position for frame {} (start frame: {}, len: {})",
                 entity,
-                time.entity_simulation_frame(player_frame_simulated),
+                frame_number,
                 position.buffer.start_frame(),
                 position.buffer.len()
             );

--- a/libs/shared_lib/src/game/movement.rs
+++ b/libs/shared_lib/src/game/movement.rs
@@ -25,8 +25,8 @@ use bevy_rapier3d::rapier::{
 /// Positions should align in half a second.
 const LERP_FACTOR: f32 = 1.0 / SIMULATIONS_PER_SECOND as f32 * 2.0;
 
-// The scaling factor for the player's linear velocity
-const PLAYER_MOVEMENT_SPEED: f32 = 2.0;
+/// The scaling factor for the player's linear velocity.
+const PLAYER_MOVEMENT_SPEED: f32 = 240.0 / SIMULATIONS_PER_SECOND as f32;
 
 pub fn read_movement_updates(
     time: Res<GameTime>,

--- a/libs/shared_lib/src/game/movement.rs
+++ b/libs/shared_lib/src/game/movement.rs
@@ -222,7 +222,7 @@ pub fn load_object_positions(
             // This can happen only if our `sync_position` haven't created a new position for
             // the current frame. If we are catching this, it's definitely a bug.
             panic!(
-                "Expected player (entity: {:?}) position for frame {} (start frame: {}, len: {})",
+                "Expected object (entity: {:?}) position for frame {} (start frame: {}, len: {})",
                 entity,
                 time.entity_simulation_frame(player_frame_simulated),
                 position.buffer.start_frame(),

--- a/libs/shared_lib/src/game/movement.rs
+++ b/libs/shared_lib/src/game/movement.rs
@@ -94,20 +94,25 @@ pub fn read_movement_updates(
                 .buffer
                 .get(frame_number)
                 .and_then(|update| *update);
-            player_direction.buffer.insert(
+            log::trace!(
+                "Inserting player direction update for frame {} (current frame: {}): {:?} (current: {:?})",
                 frame_number,
-                direction_update
-                    .and_then(|direction_update| {
-                        direction_update.as_mut().map(|direction_update| {
-                            if cfg!(feature = "client") {
-                                direction_update.is_processed_client_input = Some(true);
-                            }
-                            direction_update.direction
-                        })
-                    })
-                    // Avoid replacing initial updates with None.
-                    .or(current_direction),
+                time.frame_number,
+                direction_update,
+                current_direction,
             );
+            let update = direction_update
+                .and_then(|direction_update| {
+                    direction_update.as_mut().map(|direction_update| {
+                        if cfg!(feature = "client") {
+                            direction_update.is_processed_client_input = Some(true);
+                        }
+                        direction_update.direction
+                    })
+                })
+                // Avoid replacing initial updates with None.
+                .or(current_direction);
+            player_direction.buffer.insert(frame_number, update);
         }
     }
 }

--- a/libs/shared_lib/src/game/spawn.rs
+++ b/libs/shared_lib/src/game/spawn.rs
@@ -1,4 +1,5 @@
 use crate::{
+    framebuffer::FrameNumber,
     game::{
         client_factories::{
             ClientFactory, CubeClientFactory, PbrClientParams, PlaneClientFactory,
@@ -220,14 +221,21 @@ pub fn update_level_objects(
         };
         if let Some(position) = command.object.desc.position() {
             let position_component = if let Some(mut position_component) = position_component {
-                for frame_number in
-                    time.server_frame..=position_component.buffer.end_frame().max(time.server_frame)
+                for frame_number in command.frame_number
+                    ..=position_component
+                        .buffer
+                        .end_frame()
+                        .max(command.frame_number + FrameNumber::new(time.player_frames_ahead()))
                 {
                     position_component.buffer.insert(frame_number, position);
                 }
                 position_component
             } else {
-                Position::new(position, time.server_frame, time.player_frames_ahead() + 1)
+                Position::new(
+                    position,
+                    command.frame_number,
+                    time.player_frames_ahead() + 1,
+                )
             };
             entity_commands.insert(position_component);
         }

--- a/libs/shared_lib/src/game/spawn.rs
+++ b/libs/shared_lib/src/game/spawn.rs
@@ -58,9 +58,7 @@ pub fn spawn_players(
             let (_, mut spawned, mut position, mut player_direction) =
                 players.get_mut(entity).unwrap();
             for frame_number in time.server_frame..=time.player_frame {
-                position
-                    .buffer
-                    .insert(frame_number, command.start_position);
+                position.buffer.insert(frame_number, command.start_position);
                 player_direction
                     .buffer
                     .insert(frame_number, Some(Vec2::ZERO));

--- a/libs/shared_lib/src/game/spawn.rs
+++ b/libs/shared_lib/src/game/spawn.rs
@@ -2,8 +2,8 @@ use crate::{
     framebuffer::FrameNumber,
     game::{
         client_factories::{
-            ClientFactory, CubeClientFactory, PbrClientParams, PivotPointClientFactory,
-            PlaneClientFactory, PlayerClientFactory,
+            ClientFactory, CubeClientFactory, PbrClientParams, PlaneClientFactory,
+            PlayerClientFactory, RoutePointClientFactory,
         },
         commands::{
             DeferredQueue, DespawnLevelObject, DespawnPlayer, SpawnPlayer, UpdateLevelObject,
@@ -210,10 +210,10 @@ pub fn update_level_objects(
                 &mut pbr_client_params,
                 cube,
             ),
-            LevelObjectDesc::PivotPoint(pivot_point) => PivotPointClientFactory::insert_components(
+            LevelObjectDesc::RoutePoint(route_point) => RoutePointClientFactory::insert_components(
                 &mut entity_commands,
                 &mut pbr_client_params,
-                pivot_point,
+                route_point,
             ),
         };
         if let Some(position) = command.object.desc.position() {
@@ -287,8 +287,8 @@ pub fn despawn_level_objects(
             LevelObjectDesc::Cube(_) => {
                 CubeClientFactory::remove_components(&mut commands.entity(entity))
             }
-            LevelObjectDesc::PivotPoint(_) => {
-                PivotPointClientFactory::remove_components(&mut commands.entity(entity))
+            LevelObjectDesc::RoutePoint(_) => {
+                RoutePointClientFactory::remove_components(&mut commands.entity(entity))
             }
         }
         spawned.push_command(command.frame_number, SpawnCommand::Despawn);

--- a/libs/shared_lib/src/game/spawn.rs
+++ b/libs/shared_lib/src/game/spawn.rs
@@ -8,10 +8,7 @@ use crate::{
         commands::{
             DeferredQueue, DespawnLevelObject, DespawnPlayer, SpawnPlayer, UpdateLevelObject,
         },
-        components::{
-            LevelObjectLabel, LevelObjectTag, PlayerDirection, PlayerTag, Position, SpawnCommand,
-            Spawned,
-        },
+        components::{LevelObjectTag, PlayerDirection, PlayerTag, Position, SpawnCommand, Spawned},
         level::{LevelObjectDesc, LevelState},
     },
     messages::{EntityNetId, PlayerNetId},
@@ -214,11 +211,6 @@ pub fn update_level_objects(
         let (rigid_body, collider) = command.object.desc.physics_body();
         entity_commands
             .insert(LevelObjectTag)
-            .insert(LevelObjectLabel(format!(
-                "{} {}",
-                command.object.desc.label(),
-                command.object.net_id.0
-            )))
             .insert_bundle(rigid_body)
             .insert_bundle(collider)
             .insert(ColliderPositionSync::Discrete)

--- a/libs/shared_lib/src/game/spawn.rs
+++ b/libs/shared_lib/src/game/spawn.rs
@@ -8,7 +8,10 @@ use crate::{
         commands::{
             DeferredQueue, DespawnLevelObject, DespawnPlayer, SpawnPlayer, UpdateLevelObject,
         },
-        components::{LevelObjectTag, PlayerDirection, PlayerTag, Position, SpawnCommand, Spawned},
+        components::{
+            LevelObjectLabel, LevelObjectTag, PlayerDirection, PlayerTag, Position, SpawnCommand,
+            Spawned,
+        },
         level::{LevelObjectDesc, LevelState},
     },
     messages::{EntityNetId, PlayerNetId},
@@ -223,11 +226,10 @@ pub fn update_level_objects(
         let (rigid_body, collider) = command.object.desc.physics_body();
         entity_commands
             .insert(LevelObjectTag)
+            .insert(LevelObjectLabel(command.object.label))
             .insert_bundle(rigid_body)
             .insert_bundle(collider)
-            .insert(ColliderPositionSync::Discrete);
-        entity_commands
-            .insert(LevelObjectTag)
+            .insert(ColliderPositionSync::Discrete)
             .insert(spawned_component);
         object_entities.register(command.object.net_id, entity_commands.id());
     }

--- a/libs/shared_lib/src/game/spawn.rs
+++ b/libs/shared_lib/src/game/spawn.rs
@@ -1,5 +1,4 @@
 use crate::{
-    framebuffer::FrameNumber,
     game::{
         client_factories::{
             ClientFactory, CubeClientFactory, PbrClientParams, PlaneClientFactory,
@@ -58,13 +57,14 @@ pub fn spawn_players(
 
             let (_, mut spawned, mut position, mut player_direction) =
                 players.get_mut(entity).unwrap();
-            position.buffer.insert(
-                time.player_frame + FrameNumber::new(1),
-                command.start_position,
-            );
-            player_direction
-                .buffer
-                .insert(time.player_frame + FrameNumber::new(1), Some(Vec2::ZERO));
+            for frame_number in time.server_frame..=time.player_frame {
+                position
+                    .buffer
+                    .insert(frame_number, command.start_position);
+                player_direction
+                    .buffer
+                    .insert(frame_number, Some(Vec2::ZERO));
+            }
             PlayerClientFactory::insert_components(
                 &mut entity_commands,
                 &mut pbr_client_params,

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -258,6 +258,9 @@ impl<S: System<In = (), Out = ShouldRun>> Plugin for MuddleSharedPlugin<S> {
 
         builder.add_startup_system(network_setup.system());
 
+        #[cfg(feature = "client")]
+        builder.add_startup_system(crate::client::materials::init_object_materials.system());
+
         let resources = builder.world_mut();
         resources.get_resource_or_insert_with(GameTime::default);
         resources.get_resource_or_insert_with(SimulationTime::default);

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(const_fn_trait_bound)]
 #![feature(hash_drain_filter)]
 #![feature(step_trait)]
 #![feature(trait_alias)]

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -88,7 +88,7 @@ pub mod stage {
 }
 pub const PLAYER_SIZE: f32 = 0.5;
 pub const PLANE_SIZE: f32 = 20.0;
-pub const SIMULATIONS_PER_SECOND: u16 = 30;
+pub const SIMULATIONS_PER_SECOND: u16 = 120;
 pub const COMPONENT_FRAMEBUFFER_LIMIT: u16 = 120 * 10; // 10 seconds of 120fps
 pub const TICKS_PER_NETWORK_BROADCAST: u16 = 2;
 

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -86,6 +86,7 @@ pub mod stage {
     pub const POST_PHYSICS: &str = "mr_shared_post_physics";
     pub const POST_GAME: &str = "mr_shared_post_game";
 }
+pub const GHOST_SIZE_MULTIPLIER: f32 = 1.001;
 pub const PLAYER_SIZE: f32 = 0.5;
 pub const PLANE_SIZE: f32 = 20.0;
 pub const SIMULATIONS_PER_SECOND: u16 = 120;

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -86,7 +86,7 @@ pub mod stage {
 }
 pub const PLAYER_SIZE: f32 = 0.5;
 pub const PLANE_SIZE: f32 = 20.0;
-pub const SIMULATIONS_PER_SECOND: u16 = 120;
+pub const SIMULATIONS_PER_SECOND: u16 = 30;
 pub const COMPONENT_FRAMEBUFFER_LIMIT: u16 = 120 * 10; // 10 seconds of 120fps
 pub const TICKS_PER_NETWORK_BROADCAST: u16 = 2;
 

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -352,6 +352,29 @@ impl SimulationTime {
         assert!(self.player_frame >= self.server_frame);
         (self.player_frame - self.server_frame).value()
     }
+
+    pub fn prev_frame(&self) -> SimulationTime {
+        assert!(
+            (self.player_frame.value() > 0 || self.player_generation > 0)
+                && (self.server_frame.value() > 0 || self.server_generation > 0)
+        );
+        let player_generation = if self.player_frame == FrameNumber::new(0) {
+            self.player_generation - 1
+        } else {
+            self.player_generation
+        };
+        let server_generation = if self.server_frame == FrameNumber::new(0) {
+            self.server_generation - 1
+        } else {
+            self.server_generation
+        };
+        Self {
+            player_frame: self.player_frame - FrameNumber::new(1),
+            player_generation,
+            server_frame: self.server_frame - FrameNumber::new(1),
+            server_generation,
+        }
+    }
 }
 
 #[derive(Default, Clone)]

--- a/libs/shared_lib/src/lib.rs
+++ b/libs/shared_lib/src/lib.rs
@@ -305,12 +305,14 @@ pub enum GameState {
 
 #[derive(Default, Clone, PartialEq, Debug)]
 pub struct GameTime {
-    pub generation: usize,
+    pub session: usize,
     pub frame_number: FrameNumber,
 }
 
 #[derive(Default, Debug)]
 pub struct SimulationTime {
+    /// Corresponds to the server frame.
+    pub generation: u64,
     /// Is expected to be ahead of `server_frame` on the client side, is equal to `server_frame`
     /// on the server side.
     pub player_frame: FrameNumber,
@@ -374,8 +376,8 @@ impl GameTickRunCriteria {
         mut state: Local<GameTickRunCriteriaState>,
         time: Res<GameTime>,
     ) -> ShouldRun {
-        if state.last_generation != Some(time.generation) {
-            state.last_generation = Some(time.generation);
+        if state.last_generation != Some(time.session) {
+            state.last_generation = Some(time.session);
             state.last_tick = time.frame_number - state.ticks_per_step;
         }
 
@@ -567,6 +569,9 @@ pub fn tick_simulation_frame(mut time: ResMut<SimulationTime>) {
         time.server_frame.value(),
         time.player_frame.value()
     );
+    if time.server_frame.value() == u16::MAX {
+        time.generation += 1;
+    }
     time.server_frame += FrameNumber::new(1);
     time.player_frame += FrameNumber::new(1);
 }

--- a/libs/shared_lib/src/messages.rs
+++ b/libs/shared_lib/src/messages.rs
@@ -137,6 +137,7 @@ pub struct StartGame {
     pub nickname: String,
     pub objects: Vec<commands::UpdateLevelObject>,
     pub players: Vec<ConnectedPlayer>,
+    pub generation: u64,
     /// Full game state encoded as a DeltaUpdate.
     pub game_state: DeltaUpdate,
 }

--- a/libs/shared_lib/src/registry.rs
+++ b/libs/shared_lib/src/registry.rs
@@ -50,7 +50,7 @@ pub trait IncrementId {
     fn increment(&mut self) -> Self;
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct EntityRegistry<K: Copy + Hash + Eq> {
     entity_by_id: HashMap<K, Entity>,
     id_by_entity: HashMap<Entity, K>,

--- a/libs/shared_lib/src/wrapped_counter.rs
+++ b/libs/shared_lib/src/wrapped_counter.rs
@@ -22,6 +22,11 @@ impl<T: Integer> WrappedCounter<T> {
     pub fn value(&self) -> T {
         self.0
     }
+
+    pub fn add(&self, rhs: Self) -> (Self, bool) {
+        let (value, overflown) = self.0.overflowing_add(&rhs.0);
+        (Self::new(value), overflown)
+    }
 }
 
 impl<T: Integer> WrappedCounter<T>

--- a/libs/shared_lib/src/wrapped_counter.rs
+++ b/libs/shared_lib/src/wrapped_counter.rs
@@ -15,7 +15,7 @@ pub trait Integer = num::Integer
 pub struct WrappedCounter<T: num::Integer + Default>(T);
 
 impl<T: Integer> WrappedCounter<T> {
-    pub fn new(value: T) -> Self {
+    pub const fn new(value: T) -> Self {
         Self(value)
     }
 
@@ -124,6 +124,25 @@ where
         } else {
             Some(start - WrappedCounter(count.as_()))
         }
+    }
+}
+
+#[cfg(feature = "client")]
+impl bevy_egui::egui::emath::Numeric for WrappedCounter<u16> {
+    const INTEGRAL: bool = true;
+
+    /// Smallest finite value
+    const MIN: Self = Self::new(0);
+
+    /// Largest finite value
+    const MAX: Self = Self::new(u16::MAX);
+
+    fn to_f64(self) -> f64 {
+        self.value() as f64
+    }
+
+    fn from_f64(num: f64) -> Self {
+        Self::new(num as u16)
     }
 }
 


### PR DESCRIPTION
TODOs:
- [x] Fix `Attached` route type
- [x] Fix crashes related to the absent client-side constraints for route settings
- [x] Fix player movement
- [x] Display buttons for spawning new objects when no other object is selected
- [x] Don't list despawned objects as available route points
- [x] Show clickable object "ghosts" at their initial positions in the builder mode
- [x] Fix displaying builder UI for newly spawned objects
- [x] Implement positioning objects with mouse
- [x] Implement dragging objects (should work only for static ones or ghosts)
- [x] Add the possibility to pick objects via UI
- [x] Fix meshes and materials leak